### PR TITLE
GoogleFitImportService unit tests

### DIFF
--- a/src/Common/FitOnFhir.Common/Models/EntityBase.cs
+++ b/src/Common/FitOnFhir.Common/Models/EntityBase.cs
@@ -10,6 +10,10 @@ namespace FitOnFhir.Common.Models
 {
     public abstract class EntityBase
     {
+        public EntityBase()
+        {
+        }
+
         public EntityBase(TableEntity tableEntity)
         {
             InternalTableEntity = tableEntity;

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
@@ -1,0 +1,220 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Azure.Messaging.EventHubs;
+using FitOnFhir.Common.Exceptions;
+using FitOnFhir.Common.Tests.Mocks;
+using FitOnFhir.GoogleFit.Client;
+using FitOnFhir.GoogleFit.Client.Config;
+using FitOnFhir.GoogleFit.Client.Models;
+using FitOnFhir.GoogleFit.Client.Responses;
+using FitOnFhir.GoogleFit.Services;
+using FitOnFhir.GoogleFit.Tests.Mocks;
+using Google.Apis.Fitness.v1.Data;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Logging.Telemetry;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+using DataSource = FitOnFhir.GoogleFit.Client.Models.DataSource;
+
+namespace FitOnFhir.GoogleFit.Tests
+{
+    public class GoogleFitImportServiceTests
+    {
+        private const string _googleUserId = "me";
+        private const string _accessToken = "AccessToken";
+        private const string _refreshToken = "RefreshToken";
+        private const string _eventBody = "EventBody";
+        private const string _dataStreamId = "DataStreamId";
+        private const string _deviceUid = "DeviceUid";
+        private const string _applicationPackageName = "ApplicationPackageName";
+
+        private readonly AuthTokensResponse _tokensResponse = new AuthTokensResponse() { AccessToken = _accessToken, RefreshToken = _refreshToken };
+        private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
+        private readonly Dataset _dataset = new Dataset();
+        private readonly DataSource _dataSource = new DataSource(_dataStreamId, _deviceUid, _applicationPackageName);
+        private readonly List<DataSource> _dataSources = new List<DataSource>();
+
+        private readonly DateTimeOffset _now;
+        private readonly DateTimeOffset _oneDayBack = DateTimeOffset.Parse("01/11/2004");
+
+        private readonly GoogleFitUser _googleFitUser;
+        private readonly MockEventHubProducerClient _eventHubProducerClient;
+        private readonly MockFaultyEventHubProducerClient _faultyEventHubProducerClient;
+        private readonly EventData _eventData;
+        private readonly MedTechDataset _medTechDataset;
+
+        private readonly IGoogleFitClient _googleFitClient;
+        private readonly GoogleFitImportOptions _options;
+        private readonly Func<DateTimeOffset> _utcNowFunc;
+        private readonly MockLogger<GoogleFitImportService> _importServiceLogger;
+        private readonly ITelemetryLogger _telemetryLogger;
+        private IGoogleFitImportService _googleFitImportService;
+
+        public GoogleFitImportServiceTests()
+        {
+            // _googleFitUser = new GoogleFitUser(_googleUserId);
+            _googleFitUser = Substitute.For<GoogleFitUser>(_googleUserId);
+            _eventData = new EventData(_eventBody);
+            _medTechDataset = new MedTechDataset(_dataset, _dataSource);
+            _dataSources.Add(_dataSource);
+            _faultyEventHubProducerClient = new MockFaultyEventHubProducerClient();
+
+            // GoogleFitImportService dependencies
+            _googleFitClient = Substitute.For<IGoogleFitClient>();
+            _eventHubProducerClient = new MockEventHubProducerClient();
+            _options = Substitute.For<GoogleFitImportOptions>();
+            _utcNowFunc = Substitute.For<Func<DateTimeOffset>>();
+            _now = DateTimeOffset.Parse("01/12/2004");
+            _utcNowFunc().Returns(_now);
+            _importServiceLogger = Substitute.For<MockLogger<GoogleFitImportService>>();
+            _telemetryLogger = Substitute.For<ITelemetryLogger>();
+
+            // create the service
+            _googleFitImportService = new GoogleFitImportService(
+                _googleFitClient,
+                _eventHubProducerClient,
+                _options,
+                _utcNowFunc,
+                _importServiceLogger,
+                _telemetryLogger);
+        }
+
+        [Fact]
+        public async Task GivenNoLastSyncStored_WhenTryGetLastSyncTime_GeneratesDataSetIdForLast30Days()
+        {
+            string thirtyDaysBackDataSetId = "1071291600000000000-1073883600000000000";
+
+            await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken);
+
+            _ = _googleFitClient.Received(1).DatasetRequest(
+                Arg.Is<string>(access => access == _tokensResponse.AccessToken),
+                Arg.Is<DataSource>(ds => ds == _dataSource),
+                Arg.Is<string>(str => str == thirtyDaysBackDataSetId),
+                Arg.Is<CancellationToken>(token => token == _cancellationToken));
+        }
+
+        [Fact]
+        public async Task GivenLastSyncStored_WhenTryGetLastSyncTime_GeneratesDataSetIdForLastSync()
+        {
+            string oneDayBackDataSetId = "1073797200000000000-1073883600000000000";
+
+            _googleFitUser.TryGetLastSyncTime(_dataStreamId, out Arg.Any<DateTimeOffset>())
+                .Returns(x =>
+                {
+                    x[1] = _oneDayBack;
+                    return true;
+                });
+
+            await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken);
+
+            _ = _googleFitClient.Received(1).DatasetRequest(
+                Arg.Is<string>(access => access == _tokensResponse.AccessToken),
+                Arg.Is<DataSource>(ds => ds == _dataSource),
+                Arg.Is<string>(str => str == oneDayBackDataSetId),
+                Arg.Is<CancellationToken>(token => token == _cancellationToken));
+        }
+
+        [Fact]
+        public async Task GivenNoDataSetForDataSource_WhenDatasetRequestIsCalled_WorkerThreadContinues()
+        {
+            MedTechDataset nullMedTechDataset = null;
+            string loggerMsg = "No Dataset for: DataStreamId";
+
+            _googleFitClient.DatasetRequest(
+                Arg.Is<string>(access => access == _tokensResponse.AccessToken),
+                Arg.Any<DataSource>(),
+                Arg.Any<string>(),
+                Arg.Is<CancellationToken>(token => token == _cancellationToken)).Returns(nullMedTechDataset);
+
+            await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken);
+
+            _importServiceLogger.Received(1).Log(
+                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Information),
+                Arg.Is<string>(msg => msg == loggerMsg));
+
+            Assert.Equal(0, _eventHubProducerClient.CreateBatchAsyncCalls);
+            Assert.Equal(0, _eventHubProducerClient.SendAsyncCalls);
+            _googleFitUser.DidNotReceive().SaveLastSyncTime(Arg.Any<string>(), Arg.Any<DateTimeOffset>());
+        }
+
+        [Fact]
+        public async Task GivenEventDataBatchTryAddReturnsFalse_WhenMedTechDatasetAdded_EventBatchExceptionIsLogged()
+        {
+            string exceptionMessage = "Event is too large for the batch and cannot be sent.";
+
+            // create a different service, with an EventHubProducerClient mock (_faultyEventHubProducerClient)
+            // that uses a TryAdd callback override which returns false
+            _googleFitImportService = new GoogleFitImportService(
+                _googleFitClient,
+                _faultyEventHubProducerClient,
+                _options,
+                _utcNowFunc,
+                _importServiceLogger,
+                _telemetryLogger);
+
+            SetupMockSuccessReturns();
+
+            await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken);
+
+            _importServiceLogger.Received(1).Log(
+                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Error),
+                Arg.Any<EventBatchException>(),
+                Arg.Is<string>(msg => msg == exceptionMessage));
+        }
+
+        [Fact]
+        public void GivenDatasetRequestThrowsException_WhenProcessDatasetRequestsIsCalled_ExceptionIsThrown()
+        {
+            string exceptionMessage = "DatasetRequest exception";
+            var datasetRequestException = new Exception(exceptionMessage);
+
+            _googleFitUser.TryGetLastSyncTime(_dataStreamId, out Arg.Any<DateTimeOffset>())
+                .Returns(x =>
+                {
+                    x[1] = _oneDayBack;
+                    return true;
+                });
+
+            _googleFitClient.DatasetRequest(
+                Arg.Is<string>(access => access == _tokensResponse.AccessToken),
+                Arg.Any<DataSource>(),
+                Arg.Any<string>(),
+                Arg.Is<CancellationToken>(token => token == _cancellationToken)).Throws(datasetRequestException);
+
+            Assert.ThrowsAsync<Exception>(async () => await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken));
+        }
+
+        [Fact]
+        public async Task GivenNoConditions_WhenDatasetRequestIsCalled_Completes()
+        {
+            SetupMockSuccessReturns();
+
+            await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken);
+
+            Assert.Equal(1, _eventHubProducerClient.CreateBatchAsyncCalls);
+            Assert.Equal(1, _eventHubProducerClient.SendAsyncCalls);
+            _googleFitUser.Received(1).SaveLastSyncTime(Arg.Is<string>(str => str == _dataStreamId), Arg.Is<DateTimeOffset>(dto => dto == _utcNowFunc()));
+        }
+
+        private void SetupMockSuccessReturns()
+        {
+            _googleFitUser.TryGetLastSyncTime(_dataStreamId, out Arg.Any<DateTimeOffset>())
+                .Returns(x =>
+                {
+                    x[1] = _oneDayBack;
+                    return true;
+                });
+
+            _googleFitClient.DatasetRequest(
+                Arg.Is<string>(access => access == _tokensResponse.AccessToken),
+                Arg.Any<DataSource>(),
+                Arg.Any<string>(),
+                Arg.Is<CancellationToken>(token => token == _cancellationToken)).Returns(_medTechDataset);
+        }
+    }
+}

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
@@ -196,6 +196,7 @@ namespace FitOnFhir.GoogleFit.Tests
 
             await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken);
 
+            _googleFitUser.Received(1).TryGetLastSyncTime(Arg.Is<string>(str => str == _dataStreamId), out Arg.Any<DateTimeOffset>());
             Assert.Equal(1, _eventHubProducerClient.CreateBatchAsyncCalls);
             Assert.Equal(1, _eventHubProducerClient.SendAsyncCalls);
             _googleFitUser.Received(1).SaveLastSyncTime(Arg.Is<string>(str => str == _dataStreamId), Arg.Is<DateTimeOffset>(dto => dto == _utcNowFunc()));

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
@@ -39,8 +39,11 @@ namespace FitOnFhir.GoogleFit.Tests
         private readonly DataSource _dataSource = new DataSource(_dataStreamId, _deviceUid, _applicationPackageName);
         private readonly List<DataSource> _dataSources = new List<DataSource>();
 
-        private readonly DateTimeOffset _now;
-        private readonly DateTimeOffset _oneDayBack = DateTimeOffset.Parse("01/11/2004");
+        private readonly DateTimeOffset _now =
+            new DateTimeOffset(2004, 1, 12, 0, 0, 0, new TimeSpan(-5, 0, 0));
+
+        private readonly DateTimeOffset _oneDayBack =
+            new DateTimeOffset(2004, 1, 11, 0, 0, 0, new TimeSpan(-5, 0, 0));
 
         private readonly GoogleFitUser _googleFitUser;
         private readonly MockEventHubProducerClient _eventHubProducerClient;
@@ -57,7 +60,6 @@ namespace FitOnFhir.GoogleFit.Tests
 
         public GoogleFitImportServiceTests()
         {
-            // _googleFitUser = new GoogleFitUser(_googleUserId);
             _googleFitUser = Substitute.For<GoogleFitUser>(_googleUserId);
             _eventData = new EventData(_eventBody);
             _medTechDataset = new MedTechDataset(_dataset, _dataSource);
@@ -69,7 +71,6 @@ namespace FitOnFhir.GoogleFit.Tests
             _eventHubProducerClient = new MockEventHubProducerClient();
             _options = Substitute.For<GoogleFitImportOptions>();
             _utcNowFunc = Substitute.For<Func<DateTimeOffset>>();
-            _now = DateTimeOffset.Parse("01/12/2004");
             _utcNowFunc().Returns(_now);
             _importServiceLogger = Substitute.For<MockLogger<GoogleFitImportService>>();
             _telemetryLogger = Substitute.For<ITelemetryLogger>();

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Mocks/MockEventHubProducerClient.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Mocks/MockEventHubProducerClient.cs
@@ -1,0 +1,41 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Producer;
+
+namespace FitOnFhir.GoogleFit.Tests.Mocks
+{
+    public class MockEventHubProducerClient : EventHubProducerClient
+    {
+        private List<EventData> _eventData;
+        private int _sendAsyncCalls;
+        private int _createBatchAsyncCalls;
+
+        public MockEventHubProducerClient()
+            : base()
+        {
+            _eventData = new List<EventData>();
+        }
+
+        public IList<EventData> BatchEventData => _eventData;
+
+        public int SendAsyncCalls => _sendAsyncCalls;
+
+        public int CreateBatchAsyncCalls => _createBatchAsyncCalls;
+
+        public override ValueTask<EventDataBatch> CreateBatchAsync(CancellationToken cancellationToken)
+        {
+            _createBatchAsyncCalls++;
+            return new ValueTask<EventDataBatch>(EventHubsModelFactory.EventDataBatch(10000, BatchEventData));
+        }
+
+        public override Task SendAsync(EventDataBatch eventBatch, CancellationToken cancellationToken)
+        {
+            _sendAsyncCalls++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Mocks/MockFaultyEventHubProducerClient.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Mocks/MockFaultyEventHubProducerClient.cs
@@ -1,0 +1,56 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Producer;
+
+namespace FitOnFhir.GoogleFit.Tests.Mocks
+{
+    public class MockFaultyEventHubProducerClient : EventHubProducerClient
+    {
+        private List<EventData> _eventData;
+        private int _sendAsyncCalls;
+        private int _createBatchAsyncCalls;
+
+        public MockFaultyEventHubProducerClient()
+            : base()
+        {
+            _eventData = new List<EventData>();
+        }
+
+        public IList<EventData> BatchEventData => _eventData;
+
+        public int SendAsyncCalls => _sendAsyncCalls;
+
+        public int CreateBatchAsyncCalls => _createBatchAsyncCalls;
+
+        /// <summary>
+        /// Testing override which returns an EventDataBatch with 0 bytes in size, and adds a TryAdd callback method that returns false.
+        /// </summary>
+        /// <param name="cancellationToken">The token for canceling the operation.</param>
+        /// <returns>The <see cref="EventDataBatch"/> with a 0 size.</returns>
+        public override ValueTask<EventDataBatch> CreateBatchAsync(CancellationToken cancellationToken)
+        {
+            _createBatchAsyncCalls++;
+            return new ValueTask<EventDataBatch>(EventHubsModelFactory.EventDataBatch(0, BatchEventData, tryAddCallback: TryAddCallback));
+        }
+
+        /// <summary>
+        /// Used to simulate cases where the EventDataBatch is unable to add the EventData payload.
+        /// </summary>
+        /// <param name="arg">The <see cref="EventData"/> to add to the batch.</param>
+        /// <returns>false, indicating a mock failure.</returns>
+        private bool TryAddCallback(EventData arg)
+        {
+            return false;
+        }
+
+        public override Task SendAsync(EventDataBatch eventBatch, CancellationToken cancellationToken)
+        {
+            _sendAsyncCalls++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/GoogleFitClient.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/GoogleFitClient.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Threading;
-using System.Threading.Tasks;
 using FitOnFhir.GoogleFit.Client.Models;
 using FitOnFhir.GoogleFit.Client.Requests;
 using FitOnFhir.GoogleFit.Client.Responses;

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/GoogleFitUser.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/GoogleFitUser.cs
@@ -45,7 +45,7 @@ namespace FitOnFhir.GoogleFit.Client.Models
         /// <param name="dataStreamId">The data stream ID for the DataSource.</param>
         /// <param name="lastSyncTime">The last time a sync was executed for the data stream.</param>
         /// <returns>The <see cref="DateTimeOffset"/> for the last sync.</returns>
-        public bool TryGetLastSyncTime(string dataStreamId, out DateTimeOffset lastSyncTime)
+        public virtual bool TryGetLastSyncTime(string dataStreamId, out DateTimeOffset lastSyncTime)
         {
             EnsureArg.IsNotNullOrWhiteSpace(dataStreamId, nameof(dataStreamId));
 
@@ -65,7 +65,7 @@ namespace FitOnFhir.GoogleFit.Client.Models
         /// </summary>
         /// <param name="dataStreamId">The data stream ID for the DataSource.</param>
         /// <param name="time">The <see cref="DateTimeOffset"/> representing when this DataSource was last synced.</param>
-        public void SaveLastSyncTime(string dataStreamId, DateTimeOffset time)
+        public virtual void SaveLastSyncTime(string dataStreamId, DateTimeOffset time)
         {
             _lastSyncTimes.AddOrUpdate(dataStreamId, time, (key, oldTime) => time > oldTime ? time : oldTime);
         }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/IMedTechDataset.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/IMedTechDataset.cs
@@ -1,0 +1,28 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Azure.Messaging.EventHubs;
+using Google.Apis.Fitness.v1.Data;
+
+namespace FitOnFhir.GoogleFit.Client.Models
+{
+    public interface IMedTechDataset
+    {
+        /// <summary>
+        /// Used to retrieve the next page of <see cref="Dataset"/> results, when a <see cref="Dataset"/> request would
+        /// result in number of values that exceeds the value defined in <see cref="GoogleFitDataImporterContext"/>.GoogleFitDatasetRequestLimit.
+        /// When NextPageToken is null, there are no more results left to retrieve from the <see cref="Google.Apis.Fitness.v1.Data.DataSource"/>
+        /// for the data set ID specified.
+        /// </summary>
+        public string GetPageToken();
+
+        /// <summary>
+        /// Creates an EventData object that includes a serialized JSON represention of the IomtDataset.
+        /// </summary>
+        /// <param name="userId">The oid of the user to include in the EventData.</param>
+        /// <returns><see cref="EventData"/></returns>
+        public EventData ToEventData(string userId);
+    }
+}

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/MedTechDataset.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/MedTechDataset.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json.Linq;
 
 namespace FitOnFhir.GoogleFit.Client.Models
 {
-    public class MedTechDataset
+    public class MedTechDataset : IMedTechDataset
     {
         private readonly Dataset _dataset;
         private readonly DataSource _dataSource;
@@ -23,11 +23,13 @@ namespace FitOnFhir.GoogleFit.Client.Models
             _dataSource = EnsureArg.IsNotNull(dataSource, nameof(dataSource));
         }
 
-        /// <summary>
-        /// Creates an EventData object that includes a serialized JSON represention of the IomtDataset.
-        /// </summary>
-        /// <param name="userId">The oid of the user to include in the EventData.</param>
-        /// <returns><see cref="EventData"/></returns>
+        /// <inheritdoc/>
+        public virtual string GetPageToken()
+        {
+            return _dataset.NextPageToken;
+        }
+
+        /// <inheritdoc/>
         public EventData ToEventData(string userId)
         {
             EnsureArg.IsNotNullOrWhiteSpace(userId, nameof(userId));
@@ -37,15 +39,6 @@ namespace FitOnFhir.GoogleFit.Client.Models
             json[GoogleFitConstants.DeviceIdentifier] = GetDeviceId(userId);
 
             return new EventData(json.ToString());
-        }
-
-        /// <summary>
-        /// Accessor to the <see cref="Dataset"/>
-        /// </summary>
-        /// <returns>The current Dataset value.</returns>
-        public Dataset GetDataset()
-        {
-            return _dataset;
         }
 
         /// <summary>

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Telemetry/GoogleFitExceptionTelemetryProcessor.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Telemetry/GoogleFitExceptionTelemetryProcessor.cs
@@ -3,8 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using EnsureThat;
+using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Logging.Telemetry;
 
 namespace FitOnFhir.GoogleFit.Client.Telemetry
@@ -21,7 +21,9 @@ namespace FitOnFhir.GoogleFit.Client.Telemetry
             EnsureArg.IsNotNull(ex, nameof(ex));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
-            return base.HandleException(ex, logger);
+            var exceptionTypeName = ex.GetType().Name;
+            var handledExceptionMetric = ex is NotSupportedException ? GoogleFitMetrics.NotSupported() : GoogleFitMetrics.HandledException(exceptionTypeName, GoogleFitMetrics.ImportOperation);
+            return HandleException(ex, logger, handledExceptionMetric, GoogleFitMetrics.UnhandledException(exceptionTypeName, GoogleFitMetrics.ImportOperation));
         }
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Telemetry/GoogleFitMetrics.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Telemetry/GoogleFitMetrics.cs
@@ -1,0 +1,39 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Health.Common.Telemetry;
+
+namespace FitOnFhir.GoogleFit.Client.Telemetry
+{
+    public static class GoogleFitMetrics
+    {
+        private static Metric _notSupported = nameof(NotSupportedException).ToErrorMetric(ImportOperation, GoogleFitError, ErrorSeverity.Warning);
+
+        public static string ImportOperation => "GoogleFitImportOperation";
+
+        public static string GoogleFitError => "GoogleFitError";
+
+        /// <summary>
+        /// A metric for when FHIR resource does not support the provided type as a value.
+        /// </summary>
+        public static Metric NotSupported()
+        {
+            return _notSupported;
+        }
+
+        public static Metric UnhandledException(string exceptionName, string operation)
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(exceptionName);
+
+            return nameof(UnhandledException).ToErrorMetric(operation, ErrorType.GeneralError, ErrorSeverity.Critical, errorName: exceptionName);
+        }
+
+        public static Metric HandledException(string exceptionName, string operation)
+        {
+            return exceptionName.ToErrorMetric(operation, ErrorType.GeneralError, ErrorSeverity.Critical);
+        }
+    }
+}

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
@@ -10,7 +10,6 @@ using FitOnFhir.GoogleFit.Client;
 using FitOnFhir.GoogleFit.Client.Config;
 using FitOnFhir.GoogleFit.Client.Models;
 using FitOnFhir.GoogleFit.Client.Responses;
-using FitOnFhir.GoogleFit.Repositories;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Common.Service;
 using Microsoft.Health.Logging.Telemetry;
@@ -87,7 +86,7 @@ namespace FitOnFhir.GoogleFit.Services
                             }
 
                             // Save the NextPageToken
-                            pageToken = medTechDataset.GetDataset().NextPageToken;
+                            pageToken = medTechDataset.GetPageToken();
 
                             // Create a batch of events for MedTech Service
                             using var eventBatch = await _eventHubProducerClient.CreateBatchAsync(cancellationToken);


### PR DESCRIPTION
Unit tests covering:

- 30 day dataset ID generation when no `LastSync `is retrieved for a `DataSource`
- dataset ID generation when a `LastSync `is retrieved
- bypassing of `EventDataBatch` creation, `SendAsync` and storage of `LastSync `time for a `DataSource` when no result is returned via `DatasetRequest`
- logging of an `EventBatchException` when `TryAdd` fails for the `EventDataBatch`
- an `Exception` is thrown, and the `ExceptionService` throws
- an `AggregateException` is thrown, which the `ExceptionService` can handle and does not rethrow
- returning a `NextPageToken`, simulating multiple page results for a `Dataset` request
- normal pass through of the method with no special conditions