### PR TITLE
Revoked access token management

### DIFF
--- a/src/Common/FitOnFhir.Common/Models/DataImportState.cs
+++ b/src/Common/FitOnFhir.Common/Models/DataImportState.cs
@@ -15,12 +15,12 @@ namespace FitOnFhir.Common.Models
         /// <summary>
         /// Indicates that the data for this platform is currently being imported
         /// </summary>
-        Syncing,
+        Importing,
 
         /// <summary>
         /// Indicates that the data for this platform is ready to be synced
         /// </summary>
-        ReadyToSync,
+        ReadyToImport,
 
         /// <summary>
         /// Indicates that this platform is no longer authorized to import data for this user

--- a/src/Common/FitOnFhir.Common/Models/DataImportState.cs
+++ b/src/Common/FitOnFhir.Common/Models/DataImportState.cs
@@ -1,0 +1,30 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace FitOnFhir.Common.Models
+{
+    public enum DataImportState
+    {
+        /// <summary>
+        /// Indicates that the data for this platform is queued for importing
+        /// </summary>
+        Queued,
+
+        /// <summary>
+        /// Indicates that the data for this platform is currently being imported
+        /// </summary>
+        Syncing,
+
+        /// <summary>
+        /// Indicates that the data for this platform is ready to be synced
+        /// </summary>
+        ReadyToSync,
+
+        /// <summary>
+        /// Indicates that this platform is no longer authorized to import data for this user
+        /// </summary>
+        Unauthorized,
+    }
+}

--- a/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
+++ b/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
@@ -34,7 +34,7 @@ namespace FitOnFhir.Common.Models
 
         public override int GetHashCode()
         {
-            return PlatformName.GetHashCode() ^ UserId.GetHashCode();
+            return PlatformName.GetHashCode() ^ UserId.GetHashCode() ^ ImportState.GetHashCode();
         }
     }
 }

--- a/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
+++ b/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
@@ -7,7 +7,7 @@ using EnsureThat;
 
 namespace FitOnFhir.Common.Models
 {
-    public class PlatformUserInfo
+    public class PlatformUserInfo : IEquatable<PlatformUserInfo>
     {
         public PlatformUserInfo(string platformName, string userId, DataImportState dataImportState)
         {
@@ -21,5 +21,17 @@ namespace FitOnFhir.Common.Models
         public string UserId { get; set; }
 
         public DataImportState ImportState { get; set; }
+
+        public bool Equals(PlatformUserInfo other)
+        {
+            return PlatformName == other.PlatformName &&
+                   UserId == other.UserId &&
+                   ImportState == other.ImportState;
+        }
+
+        public override int GetHashCode()
+        {
+            return PlatformName.GetHashCode() ^ UserId.GetHashCode();
+        }
     }
 }

--- a/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
+++ b/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
@@ -4,6 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace FitOnFhir.Common.Models
 {
@@ -20,6 +22,7 @@ namespace FitOnFhir.Common.Models
 
         public string UserId { get; set; }
 
+        [JsonConverter(typeof(StringEnumConverter))]
         public DataImportState ImportState { get; set; }
 
         public bool Equals(PlatformUserInfo other)

--- a/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
+++ b/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
@@ -3,18 +3,23 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using EnsureThat;
+
 namespace FitOnFhir.Common.Models
 {
     public class PlatformUserInfo
     {
-        public PlatformUserInfo(string platformName, string userId)
+        public PlatformUserInfo(string platformName, string userId, DataImportState dataImportState)
         {
-            PlatformName = platformName;
-            UserId = userId;
+            PlatformName = EnsureArg.IsNotEmptyOrWhiteSpace(platformName, nameof(platformName));
+            UserId = EnsureArg.IsNotEmptyOrWhiteSpace(userId, nameof(userId));
+            ImportState = dataImportState;
         }
 
         public string PlatformName { get; set; }
 
         public string UserId { get; set; }
+
+        public DataImportState ImportState { get; set; }
     }
 }

--- a/src/Common/FitOnFhir.Common/Models/User.cs
+++ b/src/Common/FitOnFhir.Common/Models/User.cs
@@ -44,8 +44,7 @@ namespace FitOnFhir.Common.Models
         /// <returns>A collection of <see cref="PlatformUserInfo"/></returns>
         public IEnumerable<PlatformUserInfo> GetPlatformUserInfo()
         {
-            return _platformUserInfo.ToArray().Select(info =>
-                new PlatformUserInfo(info.Value.PlatformName, info.Value.UserId, info.Value.ImportState));
+            return _platformUserInfo.ToArray().Select(info => info.Value);
         }
 
         /// <summary>
@@ -59,7 +58,7 @@ namespace FitOnFhir.Common.Models
             _platformUserInfo.AddOrUpdate(
                 platformUserInfo.PlatformName,
                 platformUserInfo,
-                (key, info) => platformUserInfo != info ? info : platformUserInfo);
+                (key, info) => platformUserInfo != info ? platformUserInfo : info);
         }
 
         /// <summary>

--- a/src/Common/FitOnFhir.Common/Models/User.cs
+++ b/src/Common/FitOnFhir.Common/Models/User.cs
@@ -32,8 +32,7 @@ namespace FitOnFhir.Common.Models
 
             if (serializedPlatformInfo != null)
             {
-                ConcurrentDictionary<string, PlatformUserInfo> platformUserInfo = JsonConvert.DeserializeObject<ConcurrentDictionary<string, PlatformUserInfo>>(serializedPlatformInfo);
-                _platformUserInfo = new ConcurrentDictionary<string, PlatformUserInfo>(platformUserInfo);
+                _platformUserInfo = JsonConvert.DeserializeObject<ConcurrentDictionary<string, PlatformUserInfo>>(serializedPlatformInfo);
             }
         }
 
@@ -70,12 +69,9 @@ namespace FitOnFhir.Common.Models
         /// <param name="dataImportState">The new <see cref="DataImportState"/> value.</param>
         public void UpdateImportState(string platformName, DataImportState dataImportState)
         {
-            var exists = _platformUserInfo.TryGetValue(platformName, out var currentInfo);
-
-            if (exists)
+            if (_platformUserInfo.TryGetValue(platformName, out var currentInfo))
             {
-                var updateInfo = new PlatformUserInfo(platformName, currentInfo.UserId, dataImportState);
-                _platformUserInfo.TryUpdate(platformName, updateInfo, currentInfo);
+                currentInfo.ImportState = dataImportState;
             }
         }
 
@@ -88,7 +84,7 @@ namespace FitOnFhir.Common.Models
 
             if (_platformUserInfo != null && _platformUserInfo.Count > 0)
             {
-                string serializedPlatformInfo = JsonConvert.SerializeObject(_platformUserInfo.ToArray());
+                string serializedPlatformInfo = JsonConvert.SerializeObject(_platformUserInfo);
                 InternalTableEntity.Add(_platformsKey, serializedPlatformInfo);
             }
 

--- a/src/Common/FitOnFhir.Common/Repositories/ITableRepository.cs
+++ b/src/Common/FitOnFhir.Common/Repositories/ITableRepository.cs
@@ -15,11 +15,11 @@ namespace FitOnFhir.Common.Repositories
 
         Task<T> GetById(string id, CancellationToken cancellationToken);
 
-        Task Insert(T entity, CancellationToken cancellationToken);
+        Task<T> Insert(T entity, CancellationToken cancellationToken);
 
-        Task Update(T entity, CancellationToken cancellationToken);
+        Task<T> Update(T entity, CancellationToken cancellationToken);
 
-        Task Upsert(T entity, CancellationToken cancellationToken);
+        Task<T> Upsert(T entity, CancellationToken cancellationToken);
 
         Task Delete(T entity, CancellationToken cancellationToken);
     }

--- a/src/Common/FitOnFhir.Common/Repositories/TableRepository.cs
+++ b/src/Common/FitOnFhir.Common/Repositories/TableRepository.cs
@@ -7,7 +7,6 @@ using Azure;
 using Azure.Data.Tables;
 using EnsureThat;
 using FitOnFhir.Common.Models;
-using FitOnFhir.Common.Persistence;
 using Microsoft.Extensions.Logging;
 
 namespace FitOnFhir.Common.Repositories
@@ -48,7 +47,7 @@ namespace FitOnFhir.Common.Repositories
             return null;
         }
 
-        public async Task Insert(TEntity entity, CancellationToken cancellationToken)
+        public async Task<TEntity> Insert(TEntity entity, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(entity, nameof(entity));
 
@@ -60,9 +59,11 @@ namespace FitOnFhir.Common.Repositories
             {
                 _logger.LogError(ex, ex.Message);
             }
+
+            return await GetById(entity.Id, cancellationToken);
         }
 
-        public async Task Update(TEntity entity, CancellationToken cancellationToken)
+        public async Task<TEntity> Update(TEntity entity, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(entity, nameof(entity));
 
@@ -74,9 +75,11 @@ namespace FitOnFhir.Common.Repositories
             {
                 _logger.LogError(ex, ex.Message);
             }
+
+            return await GetById(entity.Id, cancellationToken);
         }
 
-        public async Task Upsert(TEntity entity, CancellationToken cancellationToken)
+        public async Task<TEntity> Upsert(TEntity entity, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(entity, nameof(entity));
 
@@ -88,6 +91,8 @@ namespace FitOnFhir.Common.Repositories
             {
                 _logger.LogError(ex, ex.Message);
             }
+
+            return await GetById(entity.Id, cancellationToken);
         }
 
         public async Task Delete(TEntity entity, CancellationToken cancellationToken)

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitDataImporterTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitDataImporterTests.cs
@@ -94,6 +94,10 @@ namespace FitOnFhir.GoogleFit.Tests
                 Arg.Is<string>(usr => usr == _userId),
                 Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken));
 
+            await _usersTableRepository.Received(2).Update(
+                Arg.Is<User>(usr => usr == _user),
+                Arg.Is<CancellationToken>(token => token == _cancellationToken));
+
             Assert.Equal(DataImportState.Unauthorized, _user.GetPlatformUserInfo().First().ImportState);
 
             await _googleFitClient.DidNotReceive().DataSourcesListRequest(
@@ -108,10 +112,6 @@ namespace FitOnFhir.GoogleFit.Tests
 
             await _googleFitUserTableRepository.DidNotReceive().Update(
                 Arg.Is<GoogleFitUser>(usr => usr == _googleFitUser),
-                Arg.Is<CancellationToken>(token => token == _cancellationToken));
-
-            await _usersTableRepository.DidNotReceive().Update(
-                Arg.Is<User>(usr => usr == _user),
                 Arg.Is<CancellationToken>(token => token == _cancellationToken));
         }
 
@@ -216,7 +216,7 @@ namespace FitOnFhir.GoogleFit.Tests
 
             await _googleFitDataImporter.Import(_userId, _googleUserId, _cancellationToken);
 
-            await _usersTableRepository.Received(1).Update(
+            await _usersTableRepository.Received(2).Update(
                 Arg.Is<User>(usr => usr == _user),
                 Arg.Is<CancellationToken>(token => token == _cancellationToken));
         }

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitDataImporterTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitDataImporterTests.cs
@@ -47,7 +47,7 @@ namespace FitOnFhir.GoogleFit.Tests
         public GoogleFitDataImporterTests()
         {
             _googleFitUser = new GoogleFitUser(_googleUserId);
-            _user.AddPlatformUserInfo(new PlatformUserInfo(GoogleFitConstants.GoogleFitPlatformName, _googleUserId, DataImportState.ReadyToSync));
+            _user.AddPlatformUserInfo(new PlatformUserInfo(GoogleFitConstants.GoogleFitPlatformName, _googleUserId, DataImportState.ReadyToImport));
 
             // GoogleFitDataImporter dependencies
             _usersTableRepository = Substitute.For<IUsersTableRepository>();
@@ -228,7 +228,7 @@ namespace FitOnFhir.GoogleFit.Tests
 
             await _googleFitDataImporter.Import(_userId, _googleUserId, _cancellationToken);
 
-            Assert.Equal(DataImportState.ReadyToSync, _user.GetPlatformUserInfo().First().ImportState);
+            Assert.Equal(DataImportState.ReadyToImport, _user.GetPlatformUserInfo().First().ImportState);
         }
 
         private void SetupMockSuccessReturns()

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitDataImporter.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitDataImporter.cs
@@ -51,7 +51,7 @@ namespace FitOnFhir.GoogleFit.Services
             // Get user's info for LastSync date
             _logger.LogInformation("Query userInfo for user: {0}, platformId: {1}", userId, googleFitId);
             var user = await _usersTableRepository.GetById(userId, cancellationToken);
-            await UpdateUserAndImportState(user, DataImportState.Importing, cancellationToken);
+            user = await UpdateUserAndImportState(user, DataImportState.Importing, cancellationToken);
 
             try
             {
@@ -90,11 +90,11 @@ namespace FitOnFhir.GoogleFit.Services
             _logger.LogInformation("Import finalized: {0}, platformId", userId, googleFitId);
         }
 
-        private async Task UpdateUserAndImportState(User user, DataImportState dataImportState, CancellationToken cancellationToken)
+        private async Task<User> UpdateUserAndImportState(User user, DataImportState dataImportState, CancellationToken cancellationToken)
         {
             user.LastTouched = _utcNowFunc();
             user.UpdateImportState(GoogleFitConstants.GoogleFitPlatformName, dataImportState);
-            await _usersTableRepository.Update(user, cancellationToken);
+            return await _usersTableRepository.Update(user, cancellationToken);
         }
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitDataImporter.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitDataImporter.cs
@@ -52,7 +52,7 @@ namespace FitOnFhir.GoogleFit.Services
             _logger.LogInformation("Query userInfo for user: {0}, platformId: {1}", userId, googleFitId);
             var user = await _usersTableRepository.GetById(userId, cancellationToken);
 
-            user.UpdateImportState(GoogleFitConstants.GoogleFitPlatformName, DataImportState.Syncing);
+            user.UpdateImportState(GoogleFitConstants.GoogleFitPlatformName, DataImportState.Importing);
 
             try
             {
@@ -87,7 +87,7 @@ namespace FitOnFhir.GoogleFit.Services
 
             // Update LastSync column and ImportState
             user.LastTouched = _utcNowFunc();
-            user.UpdateImportState(GoogleFitConstants.GoogleFitPlatformName, DataImportState.ReadyToSync);
+            user.UpdateImportState(GoogleFitConstants.GoogleFitPlatformName, DataImportState.ReadyToImport);
             await _usersTableRepository.Update(user, cancellationToken);
 
             _logger.LogInformation("Import finalized: {0}, platformId", userId, googleFitId);

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
@@ -65,7 +65,7 @@ namespace FitOnFhir.GoogleFit.Services
 
             // Create a new user and add GoogleFit info
             User user = new User(Guid.NewGuid());
-            user.AddPlatformUserInfo(new PlatformUserInfo(GoogleFitConstants.GoogleFitPlatformName, googleUserId, DataImportState.ReadyToSync));
+            user.AddPlatformUserInfo(new PlatformUserInfo(GoogleFitConstants.GoogleFitPlatformName, googleUserId, DataImportState.ReadyToImport));
 
             // Insert user into Users Table
             await _usersTableRepository.Upsert(user, cancellationToken);

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
@@ -68,7 +68,7 @@ namespace FitOnFhir.GoogleFit.Services
             user.AddPlatformUserInfo(new PlatformUserInfo(GoogleFitConstants.GoogleFitPlatformName, googleUserId, DataImportState.ReadyToImport));
 
             // Insert user into Users Table
-            await _usersTableRepository.Upsert(user, cancellationToken);
+            user = await _usersTableRepository.Upsert(user, cancellationToken);
 
             GoogleFitUser googleFitUser = new GoogleFitUser(googleUserId);
 

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
@@ -65,7 +65,7 @@ namespace FitOnFhir.GoogleFit.Services
 
             // Create a new user and add GoogleFit info
             User user = new User(Guid.NewGuid());
-            user.AddPlatformUserInfo(new PlatformUserInfo(GoogleFitConstants.GoogleFitPlatformName, googleUserId));
+            user.AddPlatformUserInfo(new PlatformUserInfo(GoogleFitConstants.GoogleFitPlatformName, googleUserId, DataImportState.ReadyToSync));
 
             // Insert user into Users Table
             await _usersTableRepository.Upsert(user, cancellationToken);

--- a/src/ImportTimerTrigger/FitOnFhir.ImportTimerTrigger/ImportTimerTriggerFunction.cs
+++ b/src/ImportTimerTrigger/FitOnFhir.ImportTimerTrigger/ImportTimerTriggerFunction.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
@@ -42,9 +43,10 @@ namespace FitOnFhir.ImportTimerTrigger
                 User user = new User(entity);
 
                 logger.LogInformation("Adding {0} to queue", user.Id);
-                IEnumerable<PlatformUserInfo> userPlatformInformation = user.GetPlatformUserInfo();
+                IEnumerable<PlatformUserInfo> userPlatformInformation = user.GetPlatformUserInfo().Where(upi => upi.ImportState != DataImportState.Unauthorized);
                 foreach (var userPlatformInfo in userPlatformInformation)
                 {
+                    user.UpdateImportState(userPlatformInfo.PlatformName, DataImportState.Queued);
                     queueService.Add(JsonConvert.SerializeObject(new QueueMessage(user.Id, userPlatformInfo.UserId, userPlatformInfo.PlatformName)));
                 }
             }

--- a/src/ImportTimerTrigger/FitOnFhir.ImportTimerTrigger/ImportTimerTriggerFunction.cs
+++ b/src/ImportTimerTrigger/FitOnFhir.ImportTimerTrigger/ImportTimerTriggerFunction.cs
@@ -43,7 +43,7 @@ namespace FitOnFhir.ImportTimerTrigger
                 User user = new User(entity);
 
                 logger.LogInformation("Adding {0} to queue", user.Id);
-                IEnumerable<PlatformUserInfo> userPlatformInformation = user.GetPlatformUserInfo().Where(upi => upi.ImportState != DataImportState.Unauthorized);
+                IEnumerable<PlatformUserInfo> userPlatformInformation = user.GetPlatformUserInfo().Where(upi => upi.ImportState == DataImportState.ReadyToImport);
                 foreach (var userPlatformInfo in userPlatformInformation)
                 {
                     user.UpdateImportState(userPlatformInfo.PlatformName, DataImportState.Queued);

--- a/src/ImportTimerTrigger/FitOnFhir.ImportTimerTrigger/ImportTimerTriggerFunction.cs
+++ b/src/ImportTimerTrigger/FitOnFhir.ImportTimerTrigger/ImportTimerTriggerFunction.cs
@@ -47,6 +47,7 @@ namespace FitOnFhir.ImportTimerTrigger
                 foreach (var userPlatformInfo in userPlatformInformation)
                 {
                     user.UpdateImportState(userPlatformInfo.PlatformName, DataImportState.Queued);
+                    user = await _usersTableRepository.Update(user, cancellationToken);
                     queueService.Add(JsonConvert.SerializeObject(new QueueMessage(user.Id, userPlatformInfo.UserId, userPlatformInfo.PlatformName)));
                 }
             }


### PR DESCRIPTION
Introduced a new `DataImportState` enum, which is used to track the state of the data import operation for each platform a user has authorized access for.  When a user has revoked access to a given platform, then the `ImportState` property for that platform will be set to `DataImportState.Unauthorized`.  This will prevent the import-timer from queueing import requests in the `import-data` queue for that platform, until the user has reauthorized access for that platform.