### PR TITLE
Use FHIR Patient resource to persist user info

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.7.4.23292",
-      "templateHash": "15430164931660122741"
+      "templateHash": "13882847403034593567"
     }
   },
   "parameters": {
@@ -80,6 +80,7 @@
     }
   },
   "variables": {
+    "fhirServiceUrl": "[format('https://{0}-fs-{1}.fhir.azurehealthcareapis.com', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename'))]",
     "fhirWriterRoleId": "3f88fce4-5892-4214-ae73-ba5294559913",
     "eventHubReceiverRoleId": "a638d3c7-ab3a-418d-83e6-5f17a39d4fde"
   },
@@ -408,7 +409,9 @@
         "GoogleFitAuthorizationConfiguration__ClientId": "[parameters('google_client_id')]",
         "GoogleFitAuthorizationConfiguration__ClientSecret": "[parameters('google_client_secret')]",
         "GoogleFitAuthorizationConfiguration__Scopes": "[parameters('google_fit_scopes')]",
-        "AzureConfiguration__UsersKeyVaultUri": "[format('https://kv-users-{0}{1}', parameters('basename'), environment().suffixes.keyvaultDns)]"
+        "AzureConfiguration__UsersKeyVaultUri": "[format('https://kv-users-{0}{1}', parameters('basename'), environment().suffixes.keyvaultDns)]",
+        "FhirService__Url": "[variables('fhirServiceUrl')]",
+        "FhirClient__UseManagedIdentity": "true"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Insights/components', format('ai-{0}', parameters('basename')))]",
@@ -631,7 +634,7 @@
       "properties": {
         "authenticationConfiguration": {
           "authority": "[format('{0}{1}', environment().authentication.loginEndpoint, subscription().tenantId)]",
-          "audience": "[format('https://{0}-fs-{1}.fhir.azurehealthcareapis.com', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename'))]",
+          "audience": "[variables('fhirServiceUrl')]",
           "smartProxyEnabled": false
         }
       },
@@ -826,6 +829,20 @@
       "dependsOn": [
         "[resourceId('Microsoft.HealthcareApis/workspaces/fhirservices', split(format('{0}/fs-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[0], split(format('{0}/fs-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[1])]",
         "[resourceId('Microsoft.HealthcareApis/workspaces/iotconnectors', split(format('{0}/hi-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[0], split(format('{0}/hi-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[1])]"
+      ]
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-08-01-preview",
+      "scope": "[format('Microsoft.HealthcareApis/workspaces/{0}/fhirservices/{1}', split(format('{0}/fs-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[0], split(format('{0}/fs-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[1])]",
+      "name": "[guid(format('{0}-AuthFhirWriter', resourceGroup().id))]",
+      "properties": {
+        "roleDefinitionId": "[format('{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', subscription().id, variables('fhirWriterRoleId'))]",
+        "principalId": "[reference(resourceId('Microsoft.Web/sites', format('authorize-{0}', parameters('basename'))), '2022-03-01', 'Full').identity.principalId]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', format('authorize-{0}', parameters('basename')))]",
+        "[resourceId('Microsoft.HealthcareApis/workspaces/fhirservices', split(format('{0}/fs-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[0], split(format('{0}/fs-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[1])]"
       ]
     },
     {

--- a/src/Authorization/FitOnFhir.Authorization/Startup.cs
+++ b/src/Authorization/FitOnFhir.Authorization/Startup.cs
@@ -21,6 +21,9 @@ using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Common.DependencyInjection;
+using Microsoft.Health.Extensions.Fhir;
+using Microsoft.Health.Extensions.Fhir.Service;
+using Microsoft.Health.Logging.Telemetry;
 
 [assembly: FunctionsStartup(typeof(Startup))]
 
@@ -39,6 +42,10 @@ namespace FitOnFhir.Authorization
             builder.Services.AddSingleton<IUsersService, UsersService>();
             builder.Services.AddSingleton<IGoogleFitAuthService, GoogleFitAuthService>();
             builder.Services.AddSingleton<IRoutingService, RoutingService>();
+            builder.Services.AddSingleton<ITelemetryLogger, TelemetryLogger>();
+            builder.Services.AddFhirClient(configuration);
+            builder.Services.AddSingleton<IFhirService, FhirService>();
+            builder.Services.AddSingleton<ResourceManagementService>();
             builder.Services.AddSingleton<GoogleFitAuthorizationHandler>();
             builder.Services.AddSingleton<UnknownAuthorizationHandler>();
             builder.Services.AddSingleton(sp => sp.CreateOrderedHandlerChain<RoutingRequest, Task<IActionResult>>(typeof(GoogleFitAuthorizationHandler), typeof(UnknownAuthorizationHandler)));

--- a/src/Common/FitOnFhir.Common.Tests/UsersServiceBaseTests.cs
+++ b/src/Common/FitOnFhir.Common.Tests/UsersServiceBaseTests.cs
@@ -1,0 +1,98 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using FitOnFhir.Common.Models;
+using FitOnFhir.Common.Repositories;
+using Microsoft.Health.Extensions.Fhir.Service;
+using NSubstitute;
+using Xunit;
+
+namespace FitOnFhir.Common.Tests
+{
+    public abstract class UsersServiceBaseTests
+    {
+        private static IFhirService _fhirService;
+
+        public UsersServiceBaseTests()
+        {
+            _fhirService = Substitute.For<IFhirService>();
+            ResourceService = new ResourceManagementService(_fhirService);
+            UsersTableRepository = Substitute.For<IUsersTableRepository>();
+
+            // Default responses.
+            _fhirService.SearchForResourceAsync(Hl7.Fhir.Model.ResourceType.Patient, Arg.Any<string>()).Returns(Task.FromResult(PatientBundle));
+            _fhirService.CreateResourceAsync(Arg.Any<Hl7.Fhir.Model.Patient>()).Returns(Task.FromResult(PatientBundle.Entry[0].Resource as Hl7.Fhir.Model.Patient));
+            UsersTableRepository.GetById(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new User(Guid.NewGuid()));
+        }
+
+        protected ResourceManagementService ResourceService { get; }
+
+        protected IUsersTableRepository UsersTableRepository { get; }
+
+        protected abstract Hl7.Fhir.Model.Bundle PatientBundle { get; }
+
+        protected abstract string ExpectedPatientId { get; }
+
+        protected abstract string ExpectedPatientIdentifierSystem { get; }
+
+        protected abstract string ExpectedPlatformUserId { get; }
+
+        protected abstract string ExpectedPlatform { get; }
+
+        protected abstract Func<Task> ExecuteAuthorizationCallback { get; }
+
+        [Fact]
+        public async Task GivenPatientDoesNotExist_WhenProcessAuthorizationCallbackCalled_NewPatientIsCreated()
+        {
+            _fhirService.SearchForResourceAsync(Hl7.Fhir.Model.ResourceType.Patient, Arg.Any<string>()).Returns(Task.FromResult(new Hl7.Fhir.Model.Bundle()));
+
+            await ExecuteAuthorizationCallback();
+
+            await _fhirService.Received(1).CreateResourceAsync(Arg.Is<Hl7.Fhir.Model.Patient>(x => IsExpected(x)));
+        }
+
+        [Fact]
+        public async Task GivenPatientExists_WhenProcessAuthorizationCallbackCalled_CreateResourceIsNotCalled()
+        {
+            await ExecuteAuthorizationCallback();
+
+            await _fhirService.DidNotReceive().CreateResourceAsync(Arg.Any<Hl7.Fhir.Model.Patient>());
+        }
+
+        [Fact]
+        public async Task GivenUserDoesNotExist_WhenProcessAuthorizationCallbackCalled_NewUserIsCreated()
+        {
+            UsersTableRepository.GetById(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<User>(null));
+
+            await ExecuteAuthorizationCallback();
+
+            await UsersTableRepository.Received().Insert(Arg.Is<User>(x => IsExpected(x)), Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GivenUserExists_WhenProcessAuthorizationCallbackCalled_CreateUserIsNotCalled()
+        {
+            await ExecuteAuthorizationCallback();
+
+            await UsersTableRepository.DidNotReceive().Insert(Arg.Any<User>(), Arg.Any<CancellationToken>());
+        }
+
+        private bool IsExpected(Hl7.Fhir.Model.Patient patient)
+        {
+            return string.Equals(ExpectedPatientIdentifierSystem, patient.Identifier[0].System, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(ExpectedPlatformUserId, patient.Identifier[0].Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private bool IsExpected(User user)
+        {
+            return string.Equals(ExpectedPatientId, user.Id, StringComparison.OrdinalIgnoreCase) &&
+                user.GetPlatformUserInfo().Any(x =>
+                {
+                    return string.Equals(ExpectedPlatform, x.PlatformName, StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(ExpectedPlatformUserId, x.UserId, StringComparison.OrdinalIgnoreCase);
+                });
+        }
+    }
+}

--- a/src/Common/FitOnFhir.Common/FitOnFhir.Common.csproj
+++ b/src/Common/FitOnFhir.Common/FitOnFhir.Common.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.Health.Common" Version="1.0.0-20220502.1" />
+    <PackageReference Include="Microsoft.Health.Extensions.Fhir.R4" Version="1.0.0-20220502.1" />
+    <PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.0.55" />
     <PackageReference Include="Microsoft.Health.Logging" Version="1.0.0-20220502.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Common/FitOnFhir.Common/Handlers/UnknownAuthorizationHandler.cs
+++ b/src/Common/FitOnFhir.Common/Handlers/UnknownAuthorizationHandler.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Threading.Tasks;
 using FitOnFhir.Common.Requests;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/Common/FitOnFhir.Common/Repositories/TableRepository.cs
+++ b/src/Common/FitOnFhir.Common/Repositories/TableRepository.cs
@@ -38,11 +38,17 @@ namespace FitOnFhir.Common.Repositories
         {
             EnsureArg.IsNotNullOrWhiteSpace(id, nameof(id));
 
-            var response = await _tableClient.GetEntityAsync<TableEntity>(PartitionKey, id, cancellationToken: cancellationToken);
-
-            if (response?.Value != null)
+            try
             {
-                return (TEntity)Activator.CreateInstance(typeof(TEntity), response.Value);
+                var response = await _tableClient.GetEntityAsync<TableEntity>(PartitionKey, id, cancellationToken: cancellationToken);
+
+                if (response?.Value != null)
+                {
+                    return (TEntity)Activator.CreateInstance(typeof(TEntity), response.Value);
+                }
+            }
+            catch (RequestFailedException e) when (e.Status == 404)
+            {
             }
 
             return null;

--- a/src/Common/FitOnFhir.Common/Services/UsersServiceBase.cs
+++ b/src/Common/FitOnFhir.Common/Services/UsersServiceBase.cs
@@ -6,8 +6,9 @@
 using EnsureThat;
 using FitOnFhir.Common.Models;
 using FitOnFhir.Common.Repositories;
-using Hl7.Fhir.Model;
 using Microsoft.Health.Extensions.Fhir.Service;
+using Identifier = Hl7.Fhir.Model.Identifier;
+using Patient = Hl7.Fhir.Model.Patient;
 
 namespace FitOnFhir.Common.Services
 {
@@ -22,7 +23,7 @@ namespace FitOnFhir.Common.Services
             _usersTableRepository = EnsureArg.IsNotNull(usersTableRepository, nameof(usersTableRepository));
         }
 
-        public async System.Threading.Tasks.Task EnsurePatientAndUser(string platformName, string identifier, string system, CancellationToken cancellationToken)
+        public async Task EnsurePatientAndUser(string platformName, string identifier, string system, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNullOrWhiteSpace(platformName, nameof(platformName));
             EnsureArg.IsNotNullOrWhiteSpace(identifier, nameof(identifier));

--- a/src/Common/FitOnFhir.Common/Services/UsersServiceBase.cs
+++ b/src/Common/FitOnFhir.Common/Services/UsersServiceBase.cs
@@ -1,0 +1,49 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using FitOnFhir.Common.Models;
+using FitOnFhir.Common.Repositories;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Extensions.Fhir.Service;
+
+namespace FitOnFhir.Common.Services
+{
+    public abstract class UsersServiceBase
+    {
+        private readonly ResourceManagementService _resourceManagementService;
+        private readonly IUsersTableRepository _usersTableRepository;
+
+        public UsersServiceBase(ResourceManagementService resourceManagementService, IUsersTableRepository usersTableRepository)
+        {
+            _resourceManagementService = EnsureArg.IsNotNull(resourceManagementService, nameof(resourceManagementService));
+            _usersTableRepository = EnsureArg.IsNotNull(usersTableRepository, nameof(usersTableRepository));
+        }
+
+        public async System.Threading.Tasks.Task EnsurePatientAndUser(string platformName, string identifier, string system, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(platformName, nameof(platformName));
+            EnsureArg.IsNotNullOrWhiteSpace(identifier, nameof(identifier));
+            EnsureArg.IsNotNullOrWhiteSpace(system, nameof(system));
+
+            // Get or create a Patient resource.
+            Patient patient = await _resourceManagementService.EnsureResourceByIdentityAsync<Patient>(
+                identifier,
+                system,
+                (p, id) => p.Identifier = new List<Identifier> { id });
+
+            // Check to see if the user exists in the repository.
+            User user = await _usersTableRepository.GetById(patient.Id, cancellationToken);
+
+            if (user == null)
+            {
+                // If a user does not exist, create a new user and add it to the repository.
+                user = new User(Guid.Parse(patient.Id));
+                user.AddPlatformUserInfo(new PlatformUserInfo(platformName, identifier));
+                await _usersTableRepository.Insert(user, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
@@ -8,6 +8,7 @@ using FitOnFhir.GoogleFit.Client.Models;
 using FitOnFhir.GoogleFit.Client.Responses;
 using Google.Apis.Fitness.v1.Data;
 using Hl7.Fhir.Model;
+using Claim = System.Security.Claims.Claim;
 
 namespace FitOnFhir.GoogleFit.Tests
 {
@@ -59,7 +60,7 @@ namespace FitOnFhir.GoogleFit.Tests
             {
                 AccessToken = accessToken,
                 RefreshToken = refreshToken,
-                IdToken = new JwtSecurityToken(issuer: Issuer, claims: new List<System.Security.Claims.Claim>() { new System.Security.Claims.Claim("sub", GoogleUserId) }),
+                IdToken = new JwtSecurityToken(issuer: Issuer, claims: new List<Claim>() { new Claim("sub", GoogleUserId) }),
             };
         }
 

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
@@ -3,8 +3,11 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.IdentityModel.Tokens.Jwt;
 using FitOnFhir.GoogleFit.Client.Models;
+using FitOnFhir.GoogleFit.Client.Responses;
 using Google.Apis.Fitness.v1.Data;
+using Hl7.Fhir.Model;
 
 namespace FitOnFhir.GoogleFit.Tests
 {
@@ -15,6 +18,11 @@ namespace FitOnFhir.GoogleFit.Tests
         public const string PackageName = "TestApplicationPackageName";
         public const string DataSourceId = "test:com.google.heart_rate.bpm:com.google.android.apps.fitness:user_input";
         public const string DataTypeName = "com.google.heart_rate.bpm";
+        public const string AccessToken = "TestAccessToken";
+        public const string RefreshToken = "TestRefreshToken";
+        public const string Issuer = "TestIssuer";
+        public const string GoogleUserId = "TestGoogleUserId";
+        public const string PatientId = "12345678-9101-1121-3141-516171819202";
 
         public static MedTechDataset GetMedTechDataset(string deviceUid = DeviceUid, string packageName = PackageName, int pointCount = 1)
         {
@@ -43,6 +51,39 @@ namespace FitOnFhir.GoogleFit.Tests
             var dataSource = new Client.Models.DataSource(DataSourceId, deviceUid, packageName);
 
             return new MedTechDataset(dataset, dataSource);
+        }
+
+        public static AuthTokensResponse GetAuthTokensResponse(string accessToken = AccessToken, string refreshToken = RefreshToken)
+        {
+            return new AuthTokensResponse
+            {
+                AccessToken = accessToken,
+                RefreshToken = refreshToken,
+                IdToken = new JwtSecurityToken(issuer: Issuer, claims: new List<System.Security.Claims.Claim>() { new System.Security.Claims.Claim("sub", GoogleUserId) }),
+            };
+        }
+
+        public static Patient GetPatient()
+        {
+            return new Patient
+            {
+                Id = PatientId,
+            };
+        }
+
+        public static Bundle GetBundle(params Resource[] resources)
+        {
+            var entries = new List<Bundle.EntryComponent>();
+
+            foreach (Resource resource in resources)
+            {
+                entries.Add(new Bundle.EntryComponent() { Resource = resource });
+            }
+
+            return new Bundle
+            {
+                Entry = entries,
+            };
         }
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitAuthorizationHandlerTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitAuthorizationHandlerTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using FitOnFhir.Common.Models;
 using FitOnFhir.Common.Requests;
 using FitOnFhir.GoogleFit.Client.Handlers;
 using FitOnFhir.GoogleFit.Client.Responses;
@@ -72,7 +71,7 @@ namespace FitOnFhir.GoogleFit.Tests
         [Fact]
         public async Task GivenRequestHandledAndUserExists_WhenRequestIsCallback_ReturnsOkResult()
         {
-            _usersService.Initiate(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new User(Guid.NewGuid()));
+            _usersService.ProcessAuthorizationCallback(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
             var routingRequest = CreateRoutingRequest(googleFitCallbackRequest);
             var result = await _googleFitAuthorizationHandler.Evaluate(routingRequest);
@@ -86,7 +85,7 @@ namespace FitOnFhir.GoogleFit.Tests
         [Fact]
         public async Task GivenRequestHandledAndExceptionIsThrown_WhenRequestIsCallback_ReturnsNotFoundResult()
         {
-            _usersService.Initiate(Arg.Any<string>(), Arg.Any<CancellationToken>()).Throws(new Exception("exception"));
+            _usersService.ProcessAuthorizationCallback(Arg.Any<string>(), Arg.Any<CancellationToken>()).Throws(new Exception("exception"));
 
             var routingRequest = CreateRoutingRequest(googleFitCallbackRequest);
             var result = await _googleFitAuthorizationHandler.Evaluate(routingRequest);

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitDataImporterTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitDataImporterTests.cs
@@ -22,13 +22,11 @@ namespace FitOnFhir.GoogleFit.Tests
     {
         private readonly string _userId = Guid.NewGuid().ToString();
         private const string _googleUserId = "me";
-        private const string _accessToken = "AccessToken";
-        private const string _refreshToken = "RefreshToken";
         private readonly CancellationToken _cancellationToken = CancellationToken.None;
         private readonly User _user = new User(Guid.NewGuid());
         private readonly GoogleFitUser _googleFitUser;
         private readonly DataSourcesListResponse _dataSourcesListResponse = new DataSourcesListResponse() { DataSources = new List<DataSource>() };
-        private readonly AuthTokensResponse _tokensResponse = new AuthTokensResponse() { AccessToken = _accessToken, RefreshToken = _refreshToken };
+        private readonly AuthTokensResponse _tokensResponse = Data.GetAuthTokensResponse();
 
         private readonly IGoogleFitImportService _googleFitImportService;
         private readonly IUsersTableRepository _usersTableRepository;
@@ -83,7 +81,7 @@ namespace FitOnFhir.GoogleFit.Tests
             await _googleFitDataImporter.Import(_userId, _googleUserId, _cancellationToken);
 
             await _googleFitClient.DidNotReceive().DataSourcesListRequest(
-                Arg.Is<string>(access => access == _accessToken),
+                Arg.Is<string>(access => access == Data.AccessToken),
                 Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken));
 
             await _usersTableRepository.DidNotReceive().GetById(
@@ -117,7 +115,7 @@ namespace FitOnFhir.GoogleFit.Tests
             await _googleFitDataImporter.Import(_userId, _googleUserId, _cancellationToken);
 
             await _googleFitClient.Received(1).DataSourcesListRequest(
-                Arg.Is<string>(access => access == _accessToken),
+                Arg.Is<string>(access => access == Data.AccessToken),
                 Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken));
         }
 
@@ -143,7 +141,7 @@ namespace FitOnFhir.GoogleFit.Tests
             await _googleFitImportService.Received(1).ProcessDatasetRequests(
                 Arg.Is<GoogleFitUser>(usr => usr.Id == _googleUserId),
                 Arg.Is<IEnumerable<DataSource>>(list => list == _dataSourcesListResponse.DataSources),
-                Arg.Is<AuthTokensResponse>(tknrsp => tknrsp.RefreshToken == _refreshToken && tknrsp.AccessToken == _accessToken),
+                Arg.Is<AuthTokensResponse>(tknrsp => tknrsp.RefreshToken == Data.RefreshToken && tknrsp.AccessToken == Data.AccessToken),
                 Arg.Is<CancellationToken>(cancel => cancel == _cancellationToken));
         }
 

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
@@ -14,6 +14,7 @@ using FitOnFhir.GoogleFit.Services;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
+using Bundle = Hl7.Fhir.Model.Bundle;
 
 namespace FitOnFhir.GoogleFit.Tests
 {
@@ -44,7 +45,7 @@ namespace FitOnFhir.GoogleFit.Tests
             _authService.AuthTokensRequest(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(Data.GetAuthTokensResponse()));
         }
 
-        protected override Hl7.Fhir.Model.Bundle PatientBundle => Data.GetBundle(Data.GetPatient());
+        protected override Bundle PatientBundle => Data.GetBundle(Data.GetPatient());
 
         protected override Func<Task> ExecuteAuthorizationCallback => () => _usersService.ProcessAuthorizationCallback("TestAuthCode", CancellationToken.None);
 
@@ -77,7 +78,7 @@ namespace FitOnFhir.GoogleFit.Tests
         }
 
         [Fact]
-        public async Task GivenAuthServiceAuthTokensRequestReturnsNull_WhenProcessAuthorizationCallbackCalled_ExceptionIsThown()
+        public async Task GivenAuthServiceAuthTokensRequestReturnsNull_WhenProcessAuthorizationCallbackCalled_ExceptionIsThrown()
         {
             _authService.AuthTokensRequest(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<AuthTokensResponse>(null));
 
@@ -85,17 +86,17 @@ namespace FitOnFhir.GoogleFit.Tests
         }
 
         [Fact]
-        public async Task GivenAllContitionsMet_WhenProcessAuthorizationCallbackCalled_GoogleFitUserPersisted()
+        public async Task GivenAllConditionsMet_WhenProcessAuthorizationCallbackCalled_GoogleFitUserPersisted()
         {
-            await _usersService.ProcessAuthorizationCallback("TestAuthCode", CancellationToken.None);
+            await ExecuteAuthorizationCallback();
 
             await _googleFitUserRepository.Received(1).Upsert(Arg.Is<GoogleFitUser>(x => x.Id.Equals(Data.GoogleUserId)), Arg.Any<CancellationToken>());
         }
 
         [Fact]
-        public async Task GivenAllContitionsMet_WhenProcessAuthorizationCallbackCalled_RefreshTokenPersisted()
+        public async Task GivenAllConditionsMet_WhenProcessAuthorizationCallbackCalled_RefreshTokenPersisted()
         {
-            await _usersService.ProcessAuthorizationCallback("TestAuthCode", CancellationToken.None);
+            await ExecuteAuthorizationCallback();
 
             await _usersKeyVaultRepository.Received(1).Upsert(Data.GoogleUserId, Data.RefreshToken, Arg.Any<CancellationToken>());
         }

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
@@ -1,0 +1,103 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using FitOnFhir.Common.Repositories;
+using FitOnFhir.Common.Tests;
+using FitOnFhir.Common.Tests.Mocks;
+using FitOnFhir.GoogleFit.Client.Models;
+using FitOnFhir.GoogleFit.Client.Responses;
+using FitOnFhir.GoogleFit.Common;
+using FitOnFhir.GoogleFit.Repositories;
+using FitOnFhir.GoogleFit.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace FitOnFhir.GoogleFit.Tests
+{
+    public class UsersServiceTests : UsersServiceBaseTests
+    {
+        private readonly IGoogleFitUserTableRepository _googleFitUserRepository;
+        private readonly IUsersKeyVaultRepository _usersKeyVaultRepository;
+        private readonly IGoogleFitAuthService _authService;
+        private readonly MockLogger<UsersService> _logger;
+        private readonly UsersService _usersService;
+
+        public UsersServiceTests()
+        {
+            _googleFitUserRepository = Substitute.For<IGoogleFitUserTableRepository>();
+            _usersKeyVaultRepository = Substitute.For<IUsersKeyVaultRepository>();
+            _authService = Substitute.For<IGoogleFitAuthService>();
+            _logger = Substitute.For<MockLogger<UsersService>>();
+
+            _usersService = new UsersService(
+                ResourceService,
+                UsersTableRepository,
+                _googleFitUserRepository,
+                _usersKeyVaultRepository,
+                _authService,
+                _logger);
+
+            // Default responses.
+            _authService.AuthTokensRequest(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(Data.GetAuthTokensResponse()));
+        }
+
+        protected override Hl7.Fhir.Model.Bundle PatientBundle => Data.GetBundle(Data.GetPatient());
+
+        protected override Func<Task> ExecuteAuthorizationCallback => () => _usersService.ProcessAuthorizationCallback("TestAuthCode", CancellationToken.None);
+
+        protected override string ExpectedPatientIdentifierSystem => Data.Issuer;
+
+        protected override string ExpectedPatientId => Data.PatientId;
+
+        protected override string ExpectedPlatformUserId => Data.GoogleUserId;
+
+        protected override string ExpectedPlatform => GoogleFitConstants.GoogleFitPlatformName;
+
+        [Fact]
+        public async Task GivenAuthCodeIsNull_WhenProcessAuthorizationCallbackCalled_ConditionIsLogged()
+        {
+            await _usersService.ProcessAuthorizationCallback(null, CancellationToken.None);
+
+            _logger.Received(1).Log(
+                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Information),
+                Arg.Is<string>(msg => msg == "ProcessAuthorizationCallback called with no auth code"));
+        }
+
+        [Fact]
+        public async Task GivenAuthCodeIsEmpty_WhenProcessAuthorizationCallbackCalled_ConditionIsLogged()
+        {
+            await _usersService.ProcessAuthorizationCallback(string.Empty, CancellationToken.None);
+
+            _logger.Received(1).Log(
+                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Information),
+                Arg.Is<string>(msg => msg == "ProcessAuthorizationCallback called with no auth code"));
+        }
+
+        [Fact]
+        public async Task GivenAuthServiceAuthTokensRequestReturnsNull_WhenProcessAuthorizationCallbackCalled_ExceptionIsThown()
+        {
+            _authService.AuthTokensRequest(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<AuthTokensResponse>(null));
+
+            await Assert.ThrowsAsync<Exception>(async () => await ExecuteAuthorizationCallback());
+        }
+
+        [Fact]
+        public async Task GivenAllContitionsMet_WhenProcessAuthorizationCallbackCalled_GoogleFitUserPersisted()
+        {
+            await _usersService.ProcessAuthorizationCallback("TestAuthCode", CancellationToken.None);
+
+            await _googleFitUserRepository.Received(1).Upsert(Arg.Is<GoogleFitUser>(x => x.Id.Equals(Data.GoogleUserId)), Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GivenAllContitionsMet_WhenProcessAuthorizationCallbackCalled_RefreshTokenPersisted()
+        {
+            await _usersService.ProcessAuthorizationCallback("TestAuthCode", CancellationToken.None);
+
+            await _usersKeyVaultRepository.Received(1).Upsert(Data.GoogleUserId, Data.RefreshToken, Arg.Any<CancellationToken>());
+        }
+    }
+}

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
@@ -70,7 +70,7 @@ namespace FitOnFhir.GoogleFit.Client.Handlers
             try
             {
                 var accessCode = EnsureArg.IsNotNullOrWhiteSpace(request?.HttpRequest?.Query?["code"], "accessCode");
-                await _usersService.Initiate(accessCode, request.Token);
+                await _usersService.ProcessAuthorizationCallback(accessCode, request.Token);
                 return new OkObjectResult("auth flow success");
             }
             catch (Exception ex)

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitDataImportHandler.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitDataImportHandler.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Diagnostics.Eventing.Reader;
 using EnsureThat;
 using FitOnFhir.Common.Interfaces;
 using FitOnFhir.Common.Requests;

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Requests/DatasetRequest.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Requests/DatasetRequest.cs
@@ -3,9 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using EnsureThat;
 using FitOnFhir.GoogleFit.Client.Models;
 using Google.Apis.Fitness.v1;

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Requests/MyEmailRequest.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Requests/MyEmailRequest.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Threading;
-using System.Threading.Tasks;
 using FitOnFhir.GoogleFit.Client.Responses;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.PeopleService.v1;

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Responses/DatasourcesListResponse.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Responses/DatasourcesListResponse.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using FitOnFhir.GoogleFit.Client.Models;
 
 namespace FitOnFhir.GoogleFit.Client.Responses

--- a/src/GoogleFit/FitOnFhir.GoogleFit/FitOnFhir.GoogleFit.csproj
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/FitOnFhir.GoogleFit.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Google.Apis.Fitness.v1" Version="1.56.0.2454" />
     <PackageReference Include="Google.Apis.PeopleService.v1" Version="1.56.0.2616" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="3.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
@@ -27,14 +26,13 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Health.Common" Version="1.0.0-20220502.1" />
-    <PackageReference Include="Microsoft.Health.Fhir.R4.Client" Version="2.2.95" />
     <PackageReference Include="Microsoft.Health.Logging" Version="1.0.0-20220502.1" />
     <PackageReference Include="SimpleBase" Version="3.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\FitOnFhir.Common\FitOnFhir.Common.csproj" />

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
@@ -3,16 +3,10 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Threading;
-using System.Threading.Tasks;
-using FitOnFhir.Common.Models;
-
 namespace FitOnFhir.GoogleFit.Services
 {
     public interface IUsersService
     {
-        Task<User> Initiate(string accessCode, CancellationToken cancellationToken);
-
-        void QueueFitnessImport(User user);
+        Task ProcessAuthorizationCallback(string accessCode, CancellationToken cancellationToken);
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
@@ -3,56 +3,55 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using FitOnFhir.Common.Models;
 using FitOnFhir.Common.Repositories;
-using FitOnFhir.GoogleFit.Client;
+using FitOnFhir.Common.Services;
 using FitOnFhir.GoogleFit.Client.Models;
 using FitOnFhir.GoogleFit.Common;
 using FitOnFhir.GoogleFit.Repositories;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Extensions.Fhir.Service;
 
 namespace FitOnFhir.GoogleFit.Services
 {
     /// <summary>
     /// User Service.
     /// </summary>
-    public class UsersService : IUsersService
+    public class UsersService : UsersServiceBase, IUsersService
     {
-        private readonly IUsersTableRepository _usersTableRepository;
         private readonly IGoogleFitUserTableRepository _googleFitUserRepository;
-        private readonly IGoogleFitClient _googleFitClient;
-        private readonly ILogger<UsersService> _logger;
-        private readonly IUsersKeyVaultRepository _usersKeyvaultRepository;
+        private readonly IUsersKeyVaultRepository _usersKeyVaultRepository;
         private readonly IGoogleFitAuthService _authService;
+        private readonly ILogger<UsersService> _logger;
 
         public UsersService(
+            ResourceManagementService resourceManagementService,
             IUsersTableRepository usersTableRepository,
             IGoogleFitUserTableRepository googleFitUserRepository,
-            IGoogleFitClient googleFitClient,
-            IUsersKeyVaultRepository usersKeyvaultRepository,
+            IUsersKeyVaultRepository usersKeyVaultRepository,
             IGoogleFitAuthService authService,
             ILogger<UsersService> logger)
+            : base(resourceManagementService, usersTableRepository)
         {
-            _usersTableRepository = usersTableRepository;
             _googleFitUserRepository = googleFitUserRepository;
-            _googleFitClient = googleFitClient;
-            _usersKeyvaultRepository = usersKeyvaultRepository;
+            _usersKeyVaultRepository = usersKeyVaultRepository;
             _authService = authService;
             _logger = logger;
         }
 
-        public async Task<User> Initiate(string authCode, CancellationToken cancellationToken)
+        public async Task ProcessAuthorizationCallback(string authCode, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrWhiteSpace(authCode))
+            {
+                _logger.LogInformation("ProcessAuthorizationCallback called with no auth code");
+                return;
+            }
+
+            // Exchange the code for Auth, Refresh and Id tokens.
             var tokenResponse = await _authService.AuthTokensRequest(authCode, cancellationToken);
+
             if (tokenResponse == null)
             {
                 throw new Exception("Token response empty");
-            }
-
-            var emailResponse = await _googleFitClient.MyEmailRequest(tokenResponse.AccessToken, cancellationToken);
-            if (emailResponse == null)
-            {
-                throw new Exception("Email response empty");
             }
 
             // https://developers.google.com/identity/protocols/oauth2/openid-connect#an-id-tokens-payload
@@ -62,27 +61,16 @@ namespace FitOnFhir.GoogleFit.Services
             // Use sub within your application as the unique-identifier key for the user.
             // Maximum length of 255 case-sensitive ASCII characters."
             string googleUserId = tokenResponse.IdToken.Subject;
+            string tokenIssuer = tokenResponse.IdToken.Issuer;
 
-            // Create a new user and add GoogleFit info
-            User user = new User(Guid.NewGuid());
-            user.AddPlatformUserInfo(new PlatformUserInfo(GoogleFitConstants.GoogleFitPlatformName, googleUserId));
-
-            // Insert user into Users Table
-            await _usersTableRepository.Upsert(user, cancellationToken);
-
-            GoogleFitUser googleFitUser = new GoogleFitUser(googleUserId);
+            // Create a Patient and User if this is the first time the user has authorized.
+            await EnsurePatientAndUser(GoogleFitConstants.GoogleFitPlatformName, googleUserId, tokenIssuer, cancellationToken);
 
             // Insert GoogleFitUser into Users Table
-            await _googleFitUserRepository.Upsert(googleFitUser, cancellationToken);
+            await _googleFitUserRepository.Upsert(new GoogleFitUser(googleUserId), cancellationToken);
 
             // Insert refresh token into users KV by userId
-            await _usersKeyvaultRepository.Upsert(googleUserId, tokenResponse.RefreshToken, cancellationToken);
-
-            return user;
-        }
-
-        public void QueueFitnessImport(User user)
-        {
+            await _usersKeyVaultRepository.Upsert(googleUserId, tokenResponse.RefreshToken, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
- Use FHIR Patient resource to persist user info globally.
- UsersService unit tests.