### PR TITLE
Personal/namalu/sync time fix

### DIFF
--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -90,7 +90,6 @@ resource infraKvName_resource 'Microsoft.KeyVault/vaults@2019-09-01' = {
     }
     tenantId: subscription().tenantId
     enableSoftDelete: true
-    enablePurgeProtection: true
     softDeleteRetentionInDays: 30
   }
 }

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.7.4.23292",
-      "templateHash": "13882847403034593567"
+      "templateHash": "17767971378592015027"
     }
   },
   "parameters": {
@@ -148,7 +148,6 @@
         },
         "tenantId": "[subscription().tenantId]",
         "enableSoftDelete": true,
-        "enablePurgeProtection": true,
         "softDeleteRetentionInDays": 30
       }
     },

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitDataImporterTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitDataImporterTests.cs
@@ -249,6 +249,22 @@ namespace FitOnFhir.GoogleFit.Tests
             });
         }
 
+        [Fact]
+        public async Task GivenImportServiceThrows_WhenImportIsCalled_GoogleUserIsNotUpdated()
+        {
+            SetupMockSuccessReturns();
+
+            _googleFitImportService.ProcessDatasetRequests(
+                _googleFitUser,
+                Arg.Any<IEnumerable<DataSource>>(),
+                _tokensResponse,
+                Arg.Any<CancellationToken>()).Returns(x => throw new Exception());
+
+            await _googleFitDataImporter.Import(_userId, _googleUserId, _cancellationToken);
+
+            await _googleFitUserTableRepository.DidNotReceive().Update(Arg.Any<GoogleFitUser>(), Arg.Any<CancellationToken>());
+        }
+
         private void SetupMockSuccessReturns()
         {
             _googleFitTokensService.RefreshToken(

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
@@ -244,7 +244,7 @@ namespace FitOnFhir.GoogleFit.Tests
             _googleFitUser.Received(1).TryGetLastSyncTime(Arg.Is<string>(str => str == _dataStreamId), out Arg.Any<long>());
             Assert.Equal(2, _eventHubProducerClient.CreateBatchAsyncCalls);
             Assert.Equal(2, _eventHubProducerClient.SendAsyncCalls);
-            _googleFitUser.Received(2).SaveLastSyncTime(Arg.Is<string>(str => str == _dataStreamId), Arg.Is<long>(dto => dto == _lastSyncTime));
+            _googleFitUser.Received(2).SaveLastSyncTime(Arg.Is<string>(str => str == _dataStreamId), Arg.Is<long>(dto => dto == _lastSyncTime + 1));
         }
 
         [Fact]
@@ -257,7 +257,7 @@ namespace FitOnFhir.GoogleFit.Tests
             _googleFitUser.Received(1).TryGetLastSyncTime(Arg.Is<string>(str => str == _dataStreamId), out Arg.Any<long>());
             Assert.Equal(1, _eventHubProducerClient.CreateBatchAsyncCalls);
             Assert.Equal(1, _eventHubProducerClient.SendAsyncCalls);
-            _googleFitUser.Received(1).SaveLastSyncTime(Arg.Is<string>(str => str == _dataStreamId), Arg.Is<long>(dto => dto == _lastSyncTime));
+            _googleFitUser.Received(1).SaveLastSyncTime(Arg.Is<string>(str => str == _dataStreamId), Arg.Is<long>(dto => dto == _lastSyncTime + 1));
         }
 
         [Theory]

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/MedTechDatasetTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/MedTechDatasetTests.cs
@@ -35,7 +35,7 @@ namespace FitOnFhir.GoogleFit.Tests
         }
 
         [Fact]
-        public void GivenUserIdAndDeviceUid_WhenToEventDataCalled_TheEventDataContainsPatientandDeviceIdentifiers()
+        public void GivenUserIdAndDeviceUid_WhenToEventDataCalled_TheEventDataContainsPatientAndDeviceIdentifiers()
         {
             var dataset = Data.GetMedTechDataset(packageName: string.Empty);
             EventData eventData = dataset.ToEventData(Data.UserId);
@@ -46,7 +46,7 @@ namespace FitOnFhir.GoogleFit.Tests
         }
 
         [Fact]
-        public void GivenUserIdAndPackageName_WhenToEventDataCalled_TheEventDataContainsPatientandDeviceIdentifiers()
+        public void GivenUserIdAndPackageName_WhenToEventDataCalled_TheEventDataContainsPatientAndDeviceIdentifiers()
         {
             var dataset = Data.GetMedTechDataset(deviceUid: string.Empty);
             EventData eventData = dataset.ToEventData(Data.UserId);
@@ -57,7 +57,7 @@ namespace FitOnFhir.GoogleFit.Tests
         }
 
         [Fact]
-        public void GivenUserIdDeviceUidAndPackageName_WhenToEventDataCalled_TheEventDataContainsPatientandDeviceIdentifiers()
+        public void GivenUserIdDeviceUidAndPackageName_WhenToEventDataCalled_TheEventDataContainsPatientAndDeviceIdentifiers()
         {
             var dataset = Data.GetMedTechDataset();
             EventData eventData = dataset.ToEventData(Data.UserId);
@@ -90,16 +90,16 @@ namespace FitOnFhir.GoogleFit.Tests
         public void GivenOneDataPoint_WhenGetMaxStartTimeCalled_LatestStartDateReturned()
         {
             var dataset = Data.GetMedTechDataset();
-            DateTimeOffset maxStartTime = dataset.GetMaxStartTime();
-            Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(165213768021), maxStartTime);
+            long maxStartTime = dataset.GetMaxEndTimeNanos();
+            Assert.Equal(165213768021173708, maxStartTime);
         }
 
         [Fact]
         public void GivenMultipleDataPoints_WhenGetMaxStartTimeCalled_LatestStartDateReturned()
         {
             var dataset = Data.GetMedTechDataset(pointCount: 2);
-            DateTimeOffset maxStartTime = dataset.GetMaxStartTime();
-            Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(165213778021), maxStartTime);
+            long maxStartTime = dataset.GetMaxEndTimeNanos();
+            Assert.Equal(165213778021173708, maxStartTime);
         }
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/GoogleFitUser.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/GoogleFitUser.cs
@@ -15,7 +15,7 @@ namespace FitOnFhir.GoogleFit.Client.Models
     public class GoogleFitUser : EntityBase
     {
         private const string _lastSyncTimesKey = "LastSyncTimes";
-        private readonly ConcurrentDictionary<string, DateTimeOffset> _lastSyncTimes = new ConcurrentDictionary<string, DateTimeOffset>();
+        private readonly ConcurrentDictionary<string, long> _lastSyncTimes = new ConcurrentDictionary<string, long>();
 
         public GoogleFitUser()
             : base(new TableEntity())
@@ -34,7 +34,7 @@ namespace FitOnFhir.GoogleFit.Client.Models
 
             if (serializedLastSyncTimes != null)
             {
-                _lastSyncTimes = JsonConvert.DeserializeObject<ConcurrentDictionary<string, DateTimeOffset>>(serializedLastSyncTimes);
+                _lastSyncTimes = JsonConvert.DeserializeObject<ConcurrentDictionary<string, long>>(serializedLastSyncTimes);
             }
         }
 
@@ -43,19 +43,19 @@ namespace FitOnFhir.GoogleFit.Client.Models
         /// data stream ID provided
         /// </summary>
         /// <param name="dataStreamId">The data stream ID for the DataSource.</param>
-        /// <param name="lastSyncTime">The last time a sync was executed for the data stream.</param>
-        /// <returns>The <see cref="DateTimeOffset"/> for the last sync.</returns>
-        public virtual bool TryGetLastSyncTime(string dataStreamId, out DateTimeOffset lastSyncTime)
+        /// <param name="lastSyncTimeNanos">The last time a sync was executed for the data stream in nanosecond epoch time format.</param>
+        /// <returns><see cref="bool"/> true if the lastSyncTimeNanos exists.</returns>
+        public virtual bool TryGetLastSyncTime(string dataStreamId, out long lastSyncTimeNanos)
         {
             EnsureArg.IsNotNullOrWhiteSpace(dataStreamId, nameof(dataStreamId));
 
-            if (_lastSyncTimes.TryGetValue(dataStreamId, out DateTimeOffset syncTime))
+            if (_lastSyncTimes.TryGetValue(dataStreamId, out long syncTimeNanos))
             {
-                lastSyncTime = syncTime;
+                lastSyncTimeNanos = syncTimeNanos;
                 return true;
             }
 
-            lastSyncTime = default;
+            lastSyncTimeNanos = default;
             return false;
         }
 
@@ -64,8 +64,8 @@ namespace FitOnFhir.GoogleFit.Client.Models
         /// by the data stream ID.
         /// </summary>
         /// <param name="dataStreamId">The data stream ID for the DataSource.</param>
-        /// <param name="time">The <see cref="DateTimeOffset"/> representing when this DataSource was last synced.</param>
-        public virtual void SaveLastSyncTime(string dataStreamId, DateTimeOffset time)
+        /// <param name="time">The <see cref="long"/> representing when this DataSource was last synced in nanosecond epoch time format.</param>
+        public virtual void SaveLastSyncTime(string dataStreamId, long time)
         {
             _lastSyncTimes.AddOrUpdate(dataStreamId, time, (key, oldTime) => time > oldTime ? time : oldTime);
         }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/IMedTechDataset.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/IMedTechDataset.cs
@@ -20,16 +20,16 @@ namespace FitOnFhir.GoogleFit.Client.Models
         string GetPageToken();
 
         /// <summary>
-        /// Creates an EventData object that includes a serialized JSON represention of the IomtDataset.
+        /// Creates an EventData object that includes a serialized JSON representation of the IomtDataset.
         /// </summary>
         /// <param name="userId">The oid of the user to include in the EventData.</param>
         /// <returns><see cref="EventData"/></returns>
         EventData ToEventData(string userId);
 
         /// <summary>
-        /// Gets the latest (most recent) start time from all points in the Dataset.
+        /// Gets the latest (most recent) start time from all points in the Dataset in nanosecond epoch time format.
         /// </summary>
-        /// <returns><see cref="DateTimeOffset"/></returns>
-        DateTimeOffset GetMaxStartTime();
+        /// <returns><see cref="long"/></returns>
+        long GetMaxEndTimeNanos();
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/MedTechDataset.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Models/MedTechDataset.cs
@@ -29,16 +29,15 @@ namespace FitOnFhir.GoogleFit.Client.Models
             return _dataset.NextPageToken;
         }
 
-        public virtual DateTimeOffset GetMaxStartTime()
+        public virtual long GetMaxEndTimeNanos()
         {
             if (_dataset.Point != null && _dataset.Point.Any())
             {
-                DataPoint latestDataPoint = _dataset.Point.MaxBy(p => p.StartTimeNanos);
+                DataPoint latestDataPoint = _dataset.Point.MaxBy(p => p.EndTimeNanos);
 
-                if (latestDataPoint.StartTimeNanos.HasValue)
+                if (latestDataPoint.EndTimeNanos.HasValue)
                 {
-                    long startTime = (long)(latestDataPoint.StartTimeNanos.Value * 0.000001);
-                    return DateTimeOffset.FromUnixTimeMilliseconds(startTime);
+                    return latestDataPoint.EndTimeNanos.Value;
                 }
             }
 

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Telemetry/GoogleFitExceptionTelemetryProcessor.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Telemetry/GoogleFitExceptionTelemetryProcessor.cs
@@ -4,18 +4,12 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
-using Microsoft.Health.Common.Telemetry;
 using Microsoft.Health.Logging.Telemetry;
 
 namespace FitOnFhir.GoogleFit.Client.Telemetry
 {
     public class GoogleFitExceptionTelemetryProcessor : ExceptionTelemetryProcessor
     {
-        public GoogleFitExceptionTelemetryProcessor()
-            : base(typeof(AggregateException))
-        {
-        }
-
         public override bool HandleException(Exception ex, ITelemetryLogger logger)
         {
             EnsureArg.IsNotNull(ex, nameof(ex));

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitDataImporter.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitDataImporter.cs
@@ -76,13 +76,15 @@ namespace FitOnFhir.GoogleFit.Services
             try
             {
                 await _googleFitImportService.ProcessDatasetRequests(googleUser, dataSourcesList.DataSources, tokensResponse, cancellationToken);
+
+                // Persist the last sync times if no exceptions occur in the import service.
+                // This ensures if an error happens during processing, the dataset will be tried again the next import.
+                await _googleFitUserTableRepository.Update(googleUser, cancellationToken);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, ex.Message);
             }
-
-            await _googleFitUserTableRepository.Update(googleUser, cancellationToken);
 
             // Update the user as ready to import for GoogleFit
             await UpdateUserAndImportState(user, DataImportState.ReadyToImport, cancellationToken);

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
@@ -136,9 +136,10 @@ namespace FitOnFhir.GoogleFit.Services
                             if (lastStartTime != default)
                             {
                                 // Update the last sync time for this DataSource in the GoogleFitUser
+                                // 1 nanosecond is added here to prevent resubmitting the last data point.
                                 // *NOTE* The value is not persisted until all work items complete.
                                 _logger.LogInformation("Saving last sync time for Dataset: {0} for user: {1}", dataStreamId, user.Id);
-                                user.SaveLastSyncTime(dataStreamId, lastStartTime);
+                                user.SaveLastSyncTime(dataStreamId, lastStartTime++);
                             }
                             else
                             {

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
@@ -139,7 +139,7 @@ namespace FitOnFhir.GoogleFit.Services
                                 // 1 nanosecond is added here to prevent resubmitting the last data point.
                                 // *NOTE* The value is not persisted until all work items complete.
                                 _logger.LogInformation("Saving last sync time for Dataset: {0} for user: {1}", dataStreamId, user.Id);
-                                user.SaveLastSyncTime(dataStreamId, lastStartTime++);
+                                user.SaveLastSyncTime(dataStreamId, lastStartTime + 1);
                             }
                             else
                             {

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
@@ -89,7 +89,7 @@ namespace FitOnFhir.GoogleFit.Services
                             // Requests may need to be throttled to avoid 429 responses from Google.
                             if (Limiter.TryThrottle(cancellationToken, out Task delayTask, out double delayMs))
                             {
-                                // When large amounts of data are processd we may need to throttle requests to prevent exceeding the API rate limits.
+                                // When large amounts of data are processed we may need to throttle requests to prevent exceeding the API rate limits.
                                 _logger.LogInformation("Throttling request for Dataset: {0} for user: {1}. Delay ms: {2}", dataStreamId, user.Id, delayMs);
                                 await delayTask;
                             }
@@ -131,11 +131,12 @@ namespace FitOnFhir.GoogleFit.Services
                             // Calculate the latest start time in the data set.
                             // There might be a delay in when data arrives to the Google service,
                             // so always sync from the last known start date of data.
-                            DateTimeOffset lastStartTime = medTechDataset.GetMaxStartTime();
+                            long lastStartTime = medTechDataset.GetMaxEndTimeNanos();
 
                             if (lastStartTime != default)
                             {
                                 // Update the last sync time for this DataSource in the GoogleFitUser
+                                // *NOTE* The value is not persisted until all work items complete.
                                 _logger.LogInformation("Saving last sync time for Dataset: {0} for user: {1}", dataStreamId, user.Id);
                                 user.SaveLastSyncTime(dataStreamId, lastStartTime);
                             }
@@ -159,22 +160,21 @@ namespace FitOnFhir.GoogleFit.Services
             await StartWorker(workItems);
         }
 
-        private string GenerateDataSetId(DateTimeOffset lastSyncTime)
+        private string GenerateDataSetId(long lastSyncTimeNanos)
         {
-            // if this DataSource has never been synced before, then retrieve 30 days prior worth of data
-            DateTimeOffset startDateDto = _utcNowFunc().AddDays(-30);
-            if (lastSyncTime != default)
+            if (lastSyncTimeNanos == default)
             {
-                startDateDto = lastSyncTime;
+                // if this DataSource has never been synced before, then retrieve 30 days prior worth of data
+                // and convert to DateTimeOffset to so .NET unix conversion is usable
+                DateTimeOffset startDateDto = _utcNowFunc().AddDays(-30);
+                lastSyncTimeNanos = startDateDto.ToUnixTimeMilliseconds() * 1000000;
             }
 
             // Convert to DateTimeOffset to so .NET unix conversion is usable
             DateTimeOffset currentTime = _utcNowFunc();
+            long endDate = currentTime.ToUnixTimeMilliseconds() * 1000000;
 
-            // .NET unix conversion only goes as small as milliseconds, multiplying to get nanoseconds
-            var startDate = startDateDto.ToUnixTimeMilliseconds() * 1000000;
-            var endDate = currentTime.ToUnixTimeMilliseconds() * 1000000;
-            return startDate + "-" + endDate;
+            return lastSyncTimeNanos + "-" + endDate;
         }
 
         public async ValueTask DisposeAsync()


### PR DESCRIPTION
Fixed issue where the last sync time was incorrectly calculated and stored (loss of precision), causing data to be repeatedly re-imported.