### PR TITLE
Added external patient identifier to auth request

### DIFF
--- a/src/Common/FitOnFhir.Common/Constants.cs
+++ b/src/Common/FitOnFhir.Common/Constants.cs
@@ -23,5 +23,15 @@ namespace FitOnFhir.Common
         /// The name of the Azure storage queue
         /// </summary>
         public const string QueueName = "import-data";
+
+        /// <summary>
+        /// Query parameter name for patient identifier in an external system.
+        /// </summary>
+        public const string PatientIdQueryParameter = "patientId";
+
+        /// <summary>
+        /// Query parameter name for the system in which the patient identifier exists.
+        /// </summary>
+        public const string SystemQueryParameter = "system";
     }
 }

--- a/src/Common/FitOnFhir.Common/Models/AuthState.cs
+++ b/src/Common/FitOnFhir.Common/Models/AuthState.cs
@@ -1,0 +1,41 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Web;
+using EnsureThat;
+using FitOnFhir.Common.Serialization;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+
+namespace FitOnFhir.Common.Models
+{
+    public class AuthState
+    {
+        [JsonConstructor]
+        public AuthState()
+        {
+        }
+
+        public AuthState(IQueryCollection query)
+        {
+            PatientId = HttpUtility.UrlDecode(EnsureArg.IsNotNullOrWhiteSpace(query?[Constants.PatientIdQueryParameter], $"query.{Constants.PatientIdQueryParameter}"));
+            System = HttpUtility.UrlDecode(EnsureArg.IsNotNullOrWhiteSpace(query?[Constants.SystemQueryParameter], $"query.{Constants.SystemQueryParameter}"));
+        }
+
+        [JsonProperty(Constants.PatientIdQueryParameter)]
+        [JsonConverter(typeof(UrlSafeJsonConverter))]
+        public string PatientId { get; set; }
+
+        [JsonProperty(Constants.SystemQueryParameter)]
+        [JsonConverter(typeof(UrlSafeJsonConverter))]
+        public string System { get; set; }
+
+        public static AuthState Parse(string jsonString)
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(jsonString, nameof(jsonString));
+            return JsonConvert.DeserializeObject<AuthState>(jsonString);
+        }
+    }
+}

--- a/src/Common/FitOnFhir.Common/Serialization/UrlSafeJsonConverter.cs
+++ b/src/Common/FitOnFhir.Common/Serialization/UrlSafeJsonConverter.cs
@@ -1,0 +1,36 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Web;
+using Newtonsoft.Json;
+
+namespace FitOnFhir.Common.Serialization
+{
+    internal class UrlSafeJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(string);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value is string stringValue)
+            {
+                return HttpUtility.UrlDecode(stringValue);
+            }
+
+            return null;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value is string stringValue)
+            {
+                writer.WriteValue(HttpUtility.UrlEncode(stringValue));
+            }
+        }
+    }
+}

--- a/src/Common/FitOnFhir.Common/Services/UsersServiceBase.cs
+++ b/src/Common/FitOnFhir.Common/Services/UsersServiceBase.cs
@@ -24,17 +24,50 @@ namespace FitOnFhir.Common.Services
             _usersTableRepository = EnsureArg.IsNotNull(usersTableRepository, nameof(usersTableRepository));
         }
 
-        public async Task EnsurePatientAndUser(string platformName, string identifier, string system, CancellationToken cancellationToken)
+        public async Task EnsurePatientAndUser(string platformName, string platformIdentifier, string platformSystem, AuthState state, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNullOrWhiteSpace(platformName, nameof(platformName));
-            EnsureArg.IsNotNullOrWhiteSpace(identifier, nameof(identifier));
-            EnsureArg.IsNotNullOrWhiteSpace(system, nameof(system));
+            EnsureArg.IsNotNullOrWhiteSpace(platformIdentifier, nameof(platformIdentifier));
+            EnsureArg.IsNotNullOrWhiteSpace(platformSystem, nameof(platformSystem));
+            string externalPatientId = EnsureArg.IsNotNullOrWhiteSpace(state.PatientId, nameof(state.PatientId));
+            string externalSystem = EnsureArg.IsNotNullOrWhiteSpace(state.System, nameof(state.System));
 
-            // Get or create a Patient resource.
-            Patient patient = await _resourceManagementService.EnsureResourceByIdentityAsync<Patient>(
-                identifier,
-                system,
-                (p, id) => p.Identifier = new List<Identifier> { id });
+            // 1. Check if a Patient exists that contains the EXTERNAL Patient Identifier.
+            Patient patient = await _resourceManagementService.GetResourceByIdentityAsync<Patient>(externalPatientId, externalSystem);
+
+            Identifier identifierToAdd;
+
+            if (patient == null)
+            {
+                // 2. There is no Patient that exists with the EXTERNAL Patient Identifier.
+                // Create or get the Patient Resource using the PLATFORM user identifier.
+                patient = await _resourceManagementService.EnsureResourceByIdentityAsync<Patient>(
+                    platformIdentifier,
+                    platformSystem,
+                    (p, id) => p.Identifier = new List<Identifier> { id });
+
+                // Set the identifierToAdd so the EXTERNAL Patient identifier is included in the Patient identifiers.
+                identifierToAdd = new Identifier(externalSystem, externalPatientId);
+            }
+            else
+            {
+                // A Patient exists with the EXTERNAL Patient identifier.
+                // Set the identifierToAdd to ensure the PLATFORM Patient identifier is included
+                // in the Patient identifiers.
+                identifierToAdd = new Identifier(platformSystem, platformIdentifier);
+            }
+
+            if (!patient.Identifier.Any(i =>
+                {
+                    return i.System.Equals(identifierToAdd.System, StringComparison.OrdinalIgnoreCase) &&
+                    i.Value.Equals(identifierToAdd.Value, StringComparison.OrdinalIgnoreCase);
+                }))
+            {
+                // 3. A required identifier is not included in the Patient, so the identifierToAdd must be added.
+                // This ensures that both identifiers are included in the Patient Resource.
+                patient.Identifier.Add(identifierToAdd);
+                await _resourceManagementService.FhirService.UpdateResourceAsync(patient, cancellationToken: cancellationToken);
+            }
 
             // Check to see if the user exists in the repository.
             User user = await _usersTableRepository.GetById(patient.Id, cancellationToken);
@@ -43,8 +76,13 @@ namespace FitOnFhir.Common.Services
             {
                 // If a user does not exist, create a new user and add it to the repository.
                 user = new User(Guid.Parse(patient.Id));
-                user.AddPlatformUserInfo(new PlatformUserInfo(platformName, identifier, DataImportState.ReadyToImport));
+                user.AddPlatformUserInfo(new PlatformUserInfo(platformName, platformIdentifier, DataImportState.ReadyToImport));
                 await _usersTableRepository.Insert(user, cancellationToken);
+            }
+            else
+            {
+                user.UpdateImportState(platformName, DataImportState.ReadyToImport);
+                await _usersTableRepository.Update(user, cancellationToken);
             }
 
             await QueueFitnessImport(user, cancellationToken);

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.IdentityModel.Tokens.Jwt;
+using FitOnFhir.Common;
 using FitOnFhir.GoogleFit.Client.Models;
 using FitOnFhir.GoogleFit.Client.Responses;
 using Google.Apis.Fitness.v1.Data;
@@ -24,6 +25,9 @@ namespace FitOnFhir.GoogleFit.Tests
         public const string Issuer = "TestIssuer";
         public const string GoogleUserId = "TestGoogleUserId";
         public const string PatientId = "12345678-9101-1121-3141-516171819202";
+        public const string ExternalPatientId = "ExternalPatientId";
+        public const string ExternalSystem = "ExternalSystem";
+        public const string AuthorizationState = $"{{\"{Constants.PatientIdQueryParameter}\":\"{ExternalPatientId}\", \"{Constants.SystemQueryParameter}\":\"{ExternalSystem}\"}}";
 
         public static MedTechDataset GetMedTechDataset(string deviceUid = DeviceUid, string packageName = PackageName, int pointCount = 1)
         {

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitAuthorizationHandlerTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitAuthorizationHandlerTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using FitOnFhir.Common;
 using FitOnFhir.Common.Requests;
 using FitOnFhir.GoogleFit.Client.Handlers;
 using FitOnFhir.GoogleFit.Client.Responses;
@@ -56,7 +57,7 @@ namespace FitOnFhir.GoogleFit.Tests
         [Fact]
         public async Task GivenRequestHandled_WhenRequestIsForAuthorization_RedirectsUser()
         {
-            _authService.AuthUriRequest(Arg.Any<CancellationToken>()).Returns(new AuthUriResponse { Uri = _fakeRedirectUri });
+            _authService.AuthUriRequest(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new AuthUriResponse { Uri = _fakeRedirectUri });
 
             var routingRequest = CreateRoutingRequest(googleFitAuthorizeRequest);
             var result = await _googleFitAuthorizationHandler.Evaluate(routingRequest);
@@ -71,21 +72,17 @@ namespace FitOnFhir.GoogleFit.Tests
         [Fact]
         public async Task GivenRequestHandledAndUserExists_WhenRequestIsCallback_ReturnsOkResult()
         {
-            _usersService.ProcessAuthorizationCallback(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            _usersService.ProcessAuthorizationCallback(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
             var routingRequest = CreateRoutingRequest(googleFitCallbackRequest);
             var result = await _googleFitAuthorizationHandler.Evaluate(routingRequest);
-            Assert.IsType<OkObjectResult>(result);
-
-            var actualResult = result as OkObjectResult;
-            var expectedResult = new OkObjectResult("auth flow success");
-            Assert.Equal(expectedResult.Value, actualResult?.Value);
+            Assert.IsType<OkResult>(result);
         }
 
         [Fact]
         public async Task GivenRequestHandledAndExceptionIsThrown_WhenRequestIsCallback_ReturnsNotFoundResult()
         {
-            _usersService.ProcessAuthorizationCallback(Arg.Any<string>(), Arg.Any<CancellationToken>()).Throws(new Exception("exception"));
+            _usersService.ProcessAuthorizationCallback(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Throws(new Exception("exception"));
 
             var routingRequest = CreateRoutingRequest(googleFitCallbackRequest);
             var result = await _googleFitAuthorizationHandler.Evaluate(routingRequest);
@@ -100,7 +97,18 @@ namespace FitOnFhir.GoogleFit.Tests
         {
             var httpRequest = Substitute.For<HttpRequest>();
             httpRequest.Path = pathString;
-            httpRequest.Query["code"].Returns(new StringValues("access code"));
+
+            if (pathString == googleFitAuthorizeRequest)
+            {
+                httpRequest.Query[Constants.PatientIdQueryParameter].Returns(new StringValues(Data.ExternalPatientId));
+                httpRequest.Query[Constants.SystemQueryParameter].Returns(new StringValues(Data.ExternalSystem));
+            }
+            else if (pathString == googleFitCallbackRequest)
+            {
+                httpRequest.Query["code"].Returns(new StringValues("access code"));
+                httpRequest.Query["state"].Returns(new StringValues(Data.AuthorizationState));
+            }
+
             var context = new ExecutionContext();
 
             return new RoutingRequest(httpRequest, context, CancellationToken.None);

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitAuthorizationHandlerTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitAuthorizationHandlerTests.cs
@@ -76,7 +76,11 @@ namespace FitOnFhir.GoogleFit.Tests
 
             var routingRequest = CreateRoutingRequest(googleFitCallbackRequest);
             var result = await _googleFitAuthorizationHandler.Evaluate(routingRequest);
-            Assert.IsType<OkResult>(result);
+            Assert.IsType<OkObjectResult>(result);
+
+            var actualResult = result as OkObjectResult;
+            var expectedResult = new OkObjectResult("Authorization completed successfully.");
+            Assert.Equal(expectedResult.Value, actualResult?.Value);
         }
 
         [Fact]

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitTokensServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitTokensServiceTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using FitOnFhir.Common.Exceptions;
 using FitOnFhir.Common.Repositories;
 using FitOnFhir.Common.Tests.Mocks;
 using FitOnFhir.GoogleFit.Client.Responses;

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
@@ -62,25 +62,25 @@ namespace FitOnFhir.GoogleFit.Tests
         protected override string ExpectedPlatform => GoogleFitConstants.GoogleFitPlatformName;
 
         [Fact]
-        public async Task GivenAuthCodeIsNull_WhenProcessAuthorizationCallbackCalled_ConditionIsLogged()
+        public async Task GivenAuthCodeIsNull_WhenProcessAuthorizationCallbackCalled_ExceptionIsThrown()
         {
             await Assert.ThrowsAsync<Exception>(() => _usersService.ProcessAuthorizationCallback(null, Data.AuthorizationState, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GivenAuthCodeIsEmpty_WhenProcessAuthorizationCallbackCalled_ConditionIsLogged()
+        public async Task GivenAuthCodeIsEmpty_WhenProcessAuthorizationCallbackCalled_ExceptionIsThrown()
         {
             await Assert.ThrowsAsync<Exception>(() => _usersService.ProcessAuthorizationCallback(string.Empty, Data.AuthorizationState, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GivenStateIsNull_WhenProcessAuthorizationCallbackCalled_ConditionIsLogged()
+        public async Task GivenStateIsNull_WhenProcessAuthorizationCallbackCalled_ExceptionIsThrown()
         {
             await Assert.ThrowsAsync<Exception>(() => _usersService.ProcessAuthorizationCallback("TestAuthCode", null, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GivenStateIsEmpty_WhenProcessAuthorizationCallbackCalled_ConditionIsLogged()
+        public async Task GivenStateIsEmpty_WhenProcessAuthorizationCallbackCalled_ExceptionIsThrown()
         {
             await Assert.ThrowsAsync<Exception>(() => _usersService.ProcessAuthorizationCallback("TestAuthCode", string.Empty, CancellationToken.None));
         }

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
@@ -13,7 +13,6 @@ using FitOnFhir.GoogleFit.Client.Responses;
 using FitOnFhir.GoogleFit.Common;
 using FitOnFhir.GoogleFit.Repositories;
 using FitOnFhir.GoogleFit.Services;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 using Bundle = Hl7.Fhir.Model.Bundle;
@@ -52,7 +51,7 @@ namespace FitOnFhir.GoogleFit.Tests
 
         protected override Bundle PatientBundle => Data.GetBundle(Data.GetPatient());
 
-        protected override Func<Task> ExecuteAuthorizationCallback => () => _usersService.ProcessAuthorizationCallback("TestAuthCode", CancellationToken.None);
+        protected override Func<Task> ExecuteAuthorizationCallback => () => _usersService.ProcessAuthorizationCallback("TestAuthCode", Data.AuthorizationState, CancellationToken.None);
 
         protected override string ExpectedPatientIdentifierSystem => Data.Issuer;
 
@@ -65,21 +64,25 @@ namespace FitOnFhir.GoogleFit.Tests
         [Fact]
         public async Task GivenAuthCodeIsNull_WhenProcessAuthorizationCallbackCalled_ConditionIsLogged()
         {
-            await _usersService.ProcessAuthorizationCallback(null, CancellationToken.None);
-
-            _logger.Received(1).Log(
-                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Information),
-                Arg.Is<string>(msg => msg == "ProcessAuthorizationCallback called with no auth code"));
+            await Assert.ThrowsAsync<Exception>(() => _usersService.ProcessAuthorizationCallback(null, Data.AuthorizationState, CancellationToken.None));
         }
 
         [Fact]
         public async Task GivenAuthCodeIsEmpty_WhenProcessAuthorizationCallbackCalled_ConditionIsLogged()
         {
-            await _usersService.ProcessAuthorizationCallback(string.Empty, CancellationToken.None);
+            await Assert.ThrowsAsync<Exception>(() => _usersService.ProcessAuthorizationCallback(string.Empty, Data.AuthorizationState, CancellationToken.None));
+        }
 
-            _logger.Received(1).Log(
-                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Information),
-                Arg.Is<string>(msg => msg == "ProcessAuthorizationCallback called with no auth code"));
+        [Fact]
+        public async Task GivenStateIsNull_WhenProcessAuthorizationCallbackCalled_ConditionIsLogged()
+        {
+            await Assert.ThrowsAsync<Exception>(() => _usersService.ProcessAuthorizationCallback("TestAuthCode", null, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task GivenStateIsEmpty_WhenProcessAuthorizationCallbackCalled_ConditionIsLogged()
+        {
+            await Assert.ThrowsAsync<Exception>(() => _usersService.ProcessAuthorizationCallback("TestAuthCode", string.Empty, CancellationToken.None));
         }
 
         [Fact]

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
@@ -88,7 +88,7 @@ namespace FitOnFhir.GoogleFit.Client.Handlers
                     request?.HttpRequest?.Query?["state"],
                     request.Token);
 
-                return new OkResult();
+                return new OkObjectResult("Authorization completed successfully.");
             }
             catch (Exception ex)
             {

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
@@ -4,6 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
+using FitOnFhir.Common;
+using FitOnFhir.Common.Models;
 using FitOnFhir.Common.Requests;
 using FitOnFhir.GoogleFit.Client.Responses;
 using FitOnFhir.GoogleFit.Common;
@@ -11,6 +13,7 @@ using FitOnFhir.GoogleFit.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Common.Handler;
+using Newtonsoft.Json;
 
 namespace FitOnFhir.GoogleFit.Client.Handlers
 {
@@ -61,7 +64,18 @@ namespace FitOnFhir.GoogleFit.Client.Handlers
 
         private async Task<IActionResult> Authorize(RoutingRequest request)
         {
-            AuthUriResponse response = await _authService.AuthUriRequest(request.Token);
+            AuthState state = null;
+
+            try
+            {
+                state = new AuthState(request?.HttpRequest?.Query);
+            }
+            catch (ArgumentException)
+            {
+                return new BadRequestObjectResult($"'{Constants.PatientIdQueryParameter}' and '{Constants.SystemQueryParameter}' are required query parameters.");
+            }
+
+            AuthUriResponse response = await _authService.AuthUriRequest(JsonConvert.SerializeObject(state), request.Token);
             return new RedirectResult(response.Uri);
         }
 
@@ -69,9 +83,12 @@ namespace FitOnFhir.GoogleFit.Client.Handlers
         {
             try
             {
-                var accessCode = EnsureArg.IsNotNullOrWhiteSpace(request?.HttpRequest?.Query?["code"], "accessCode");
-                await _usersService.ProcessAuthorizationCallback(accessCode, request.Token);
-                return new OkObjectResult("auth flow success");
+                await _usersService.ProcessAuthorizationCallback(
+                    request?.HttpRequest?.Query?["code"],
+                    request?.HttpRequest?.Query?["state"],
+                    request.Token);
+
+                return new OkResult();
             }
             catch (Exception ex)
             {

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitAuthService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitAuthService.cs
@@ -43,12 +43,12 @@ namespace FitOnFhir.GoogleFit.Services
         }
 
         /// <inheritdoc/>
-        public async Task<AuthUriResponse> AuthUriRequest(CancellationToken cancellationToken)
+        public async Task<AuthUriResponse> AuthUriRequest(string state, CancellationToken cancellationToken)
         {
             var request = new AuthorizationCodeWebApp(
                 _googleAuthorizationCodeFlow,
                 _authorizationConfiguration.CallbackUri,
-                string.Empty);
+                state);
 
             var result = await request.AuthorizeAsync("user", cancellationToken);
             if (result.Credential == null)

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/IAuthService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/IAuthService.cs
@@ -15,9 +15,10 @@ namespace FitOnFhir.GoogleFit.Services
         /// <summary>
         /// Sends an authorization request to the platform appropriate URI.
         /// </summary>
+        /// <param name="state">A state string that will be provided in the callback.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to cancel the process.</param>
         /// <returns>The <see cref="AuthUriResponse"/> for the operation.</returns>
-        Task<AuthUriResponse> AuthUriRequest(CancellationToken cancellationToken);
+        Task<AuthUriResponse> AuthUriRequest(string state, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends a request to the platform appropriate URI for the authorization tokens.

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
@@ -9,7 +9,7 @@ namespace FitOnFhir.GoogleFit.Services
 {
     public interface IUsersService
     {
-        Task ProcessAuthorizationCallback(string accessCode, CancellationToken cancellationToken);
+        Task ProcessAuthorizationCallback(string accessCode, string state, CancellationToken cancellationToken);
 
         Task QueueFitnessImport(User user, CancellationToken cancellationToken);
     }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
@@ -44,12 +44,24 @@ namespace FitOnFhir.GoogleFit.Services
             _logger = logger;
         }
 
-        public async Task ProcessAuthorizationCallback(string authCode, CancellationToken cancellationToken)
+        public async Task ProcessAuthorizationCallback(string authCode, string state, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(authCode))
             {
-                _logger.LogInformation("ProcessAuthorizationCallback called with no auth code");
-                return;
+                // This exception message will be visible to the caller.
+                throw new Exception("The Google authorization service failed to return an access code.");
+            }
+
+            AuthState authState;
+
+            try
+            {
+                authState = AuthState.Parse(state);
+            }
+            catch (ArgumentException)
+            {
+                // This exception message will be visible to the caller.
+                throw new Exception("The Google authorization service failed to return the expected authorization state.");
             }
 
             // Exchange the code for Auth, Refresh and Id tokens.
@@ -57,7 +69,8 @@ namespace FitOnFhir.GoogleFit.Services
 
             if (tokenResponse == null)
             {
-                throw new Exception("Token response empty");
+                // This exception message will be visible to the caller.
+                throw new Exception("This Google user has already authorized data sharing.");
             }
 
             // https://developers.google.com/identity/protocols/oauth2/openid-connect#an-id-tokens-payload
@@ -70,7 +83,12 @@ namespace FitOnFhir.GoogleFit.Services
             string tokenIssuer = tokenResponse.IdToken.Issuer;
 
             // Create a Patient and User if this is the first time the user has authorized.
-            await EnsurePatientAndUser(GoogleFitConstants.GoogleFitPlatformName, googleUserId, tokenIssuer, cancellationToken);
+            await EnsurePatientAndUser(
+                GoogleFitConstants.GoogleFitPlatformName,
+                googleUserId,
+                tokenIssuer,
+                authState,
+                cancellationToken);
 
             // Insert GoogleFitUser into Users Table
             await _googleFitUserRepository.Upsert(new GoogleFitUser(googleUserId), cancellationToken);


### PR DESCRIPTION
This PR updates the authorization endpoint to require a patient identifier and and system (as query parameters) when the request is made. This is to provide a way to map the Patient Resource in FHIR with an identifier from a different system (MRN identity provider did, etc). 