### PR TITLE
Fix incorrect tests

### DIFF
--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
@@ -198,14 +198,19 @@ namespace FitOnFhir.GoogleFit.Tests
                 Arg.Any<int>(),
                 Arg.Is<CancellationToken>(token => token == _cancellationToken)).Throws(datasetRequestException);
 
+            AggregateException exception = new AggregateException();
             try
             {
                 await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken);
             }
             catch (AggregateException ex)
             {
-                Assert.NotNull(ex.InnerException);
-                Assert.Equal(datasetRequestException.Message, ex.InnerException.Message);
+                exception = ex;
+            }
+            finally
+            {
+                Assert.NotNull(exception.InnerException);
+                Assert.Equal(datasetRequestException.Message, exception.InnerException.Message);
             }
         }
 

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
@@ -180,11 +180,8 @@ namespace FitOnFhir.GoogleFit.Tests
         }
 
         [Fact]
-        public void GivenDatasetRequestThrowsException_WhenProcessDatasetRequestsIsCalled_ExceptionIsThrown()
+        public async Task GivenDatasetRequestThrowsException_WhenProcessDatasetRequestsIsCalled_AggregateExceptionIsThrown()
         {
-            string exceptionMessage = "DatasetRequest exception";
-            var datasetRequestException = new Exception(exceptionMessage);
-
             _googleFitUser.TryGetLastSyncTime(_dataStreamId, out Arg.Any<long>())
                 .Returns(x =>
                 {
@@ -192,6 +189,8 @@ namespace FitOnFhir.GoogleFit.Tests
                     return true;
                 });
 
+            string exceptionMessage = "DatasetRequest exception";
+            var datasetRequestException = new Exception(exceptionMessage);
             _googleFitClient.DatasetRequest(
                 Arg.Is<string>(access => access == _tokensResponse.AccessToken),
                 Arg.Any<DataSource>(),
@@ -199,7 +198,15 @@ namespace FitOnFhir.GoogleFit.Tests
                 Arg.Any<int>(),
                 Arg.Is<CancellationToken>(token => token == _cancellationToken)).Throws(datasetRequestException);
 
-            Assert.ThrowsAsync<Exception>(async () => await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken));
+            try
+            {
+                await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken);
+            }
+            catch (AggregateException ex)
+            {
+                Assert.NotNull(ex.InnerException);
+                Assert.Equal(datasetRequestException.Message, ex.InnerException.Message);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Discovered that a few existing tests that were looking for `Assert.ThrowsAsync<>` were not being awaited.  After awaiting those calls, I made the following changes:

1. Two tests in `QueueServiceTests` were asserting on an exception being thrown, when the test condition was supposed to be that the exception was logged.  The exceptions were in fact caught and never thrown again.
2. One test in `GoogleFitImportServiceTests` was looking for an `Exception` to be thrown, but an `AggregateException` was in fact being thrown.  This was coming from `StartWorker` in `ParallelTaskWorker`.  Changed the test to look at the `InnerException` of the `AggregateException` and verify that the message matched the expected value.