### PR TITLE
Configure historical data first import time period

### DIFF
--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -28,6 +28,9 @@ param google_max_concurrency string = '10'
 @description('The maximum number of requests that can be made to the Google APIs in a one minute period.')
 param google_max_requests_per_minute string = '300'
 
+@description('The period of time from now into the past, that the first Google Fit data import should cover.  30 days prior is the default.  Format is days.hours:minutes:seconds')
+param google_historical_import_time_span string = '30.00:00:00'
+
 @description('The Google Fit data authorization scopes allowed for users of this service (see https://developers.google.com/fit/datatypes#authorization_scopes for more info)')
 param google_fit_scopes string = 'https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/userinfo.profile,https://www.googleapis.com/auth/fitness.activity.read,https://www.googleapis.com/auth/fitness.sleep.read,https://www.googleapis.com/auth/fitness.reproductive_health.read,https://www.googleapis.com/auth/fitness.oxygen_saturation.read,https://www.googleapis.com/auth/fitness.nutrition.read,https://www.googleapis.com/auth/fitness.location.read,https://www.googleapis.com/auth/fitness.body_temperature.read,https://www.googleapis.com/auth/fitness.body.read,https://www.googleapis.com/auth/fitness.blood_pressure.read,https://www.googleapis.com/auth/fitness.blood_glucose.read,https://www.googleapis.com/auth/fitness.heart_rate.read'
 
@@ -434,6 +437,7 @@ resource import_data_basename_appsettings 'Microsoft.Web/sites/config@2015-08-01
 	  'GoogleFitDataImporterConfiguration__DatasetRequestLimit': google_dataset_request_limit
 	  'GoogleFitDataImporterConfiguration__MaxConcurrency': google_max_concurrency
     'GoogleFitDataImporterConfiguration__MaxRequestsPerMinute': google_max_requests_per_minute
+	'GoogleFitDataImporterConfiguration__HistoricalImportTimeSpan': google_historical_import_time_span
     'AzureConfiguration__UsersKeyVaultUri': 'https://kv-users-${basename}${environment().suffixes.keyvaultDns}'
   }
   dependsOn: [

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.7.4.23292",
-      "templateHash": "17767971378592015027"
+      "templateHash": "14355590407303343287"
     }
   },
   "parameters": {
@@ -69,6 +69,13 @@
       "defaultValue": "300",
       "metadata": {
         "description": "The maximum number of requests that can be made to the Google APIs in a one minute period."
+      }
+    },
+    "google_historical_import_time_span": {
+      "type": "string",
+      "defaultValue": "30.00:00:00",
+      "metadata": {
+        "description": "The period of time from now into the past, that the first Google Fit data import should cover.  30 days prior is the default.  Format is days.hours:minutes:seconds"
       }
     },
     "google_fit_scopes": {
@@ -541,6 +548,7 @@
         "GoogleFitDataImporterConfiguration__DatasetRequestLimit": "[parameters('google_dataset_request_limit')]",
         "GoogleFitDataImporterConfiguration__MaxConcurrency": "[parameters('google_max_concurrency')]",
         "GoogleFitDataImporterConfiguration__MaxRequestsPerMinute": "[parameters('google_max_requests_per_minute')]",
+        "GoogleFitDataImporterConfiguration__HistoricalImportTimeSpan": "[parameters('google_historical_import_time_span')]",
         "AzureConfiguration__UsersKeyVaultUri": "[format('https://kv-users-{0}{1}', parameters('basename'), environment().suffixes.keyvaultDns)]"
       },
       "dependsOn": [

--- a/docs/deploy-using-arm-template.md
+++ b/docs/deploy-using-arm-template.md
@@ -30,6 +30,7 @@ You must provide the following parameters when deploying the ARM Template.
 |**google_max_concurrency**|**The maximum concurrent tasks allowed per Google Fit dataset request.** *The default value is 10*|false
 |**google_fit_scopes**|**The Google Fit data authorization scopes allowed for users of this service (see [https://developers.google.com/fit/datatypes#authorization_scopes](https://developers.google.com/fit/datatypes#authorization_scopes) for more info).** *Defaults to all available scopes*|false
 |**google_max_requests_per_minute**|**The maximum number of requests that can be made to the Google APIs in a one minute period.** *Defaults to 300*|false
+|**google_historical_import_time_span**|**The time period in days, hours, minutes, and seconds from now into the past, that the first data import will cover.** *Defaults to 30 days*|false
 
 ## Provision using Azure CLI (Bicep or ARM)
 

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
@@ -73,7 +73,6 @@ namespace FitOnFhir.GoogleFit.Tests
             _options.ParallelTaskOptions.Returns(parallelTaskOptions);
             var telemetryLogger = new GoogleFitExceptionTelemetryProcessor();
             _options.ExceptionService.Returns(telemetryLogger);
-            _options.HistoricalImportTimeSpan.Returns(TimeSpan.FromDays(30));
 
             // GoogleFitImportService dependencies
             _googleFitClient = Substitute.For<IGoogleFitClient>();
@@ -94,17 +93,29 @@ namespace FitOnFhir.GoogleFit.Tests
                 _telemetryLogger);
         }
 
-        [Fact]
-        public async Task GivenNoLastSyncStored_WhenTryGetLastSyncTime_GeneratesDataSetIdForLast30Days()
+        [Theory]
+        [InlineData(30, 0, 0, 0, "1071291600000000000-1073883600000000000")]
+        [InlineData(0, 30, 0, 0, "1073775600000000000-1073883600000000000")]
+        [InlineData(0, 0, 30, 0, "1073881800000000000-1073883600000000000")]
+        [InlineData(0, 0, 0, 30, "1073883570000000000-1073883600000000000")]
+        [InlineData(30, 30, 30, 30, "1071181770000000000-1073883600000000000")]
+        [InlineData(0, 0, 0, 0, "1073883600000000000-1073883600000000000")]
+        [InlineData(-1, 0, 0, 0, "1073883600000000000-1073883600000000000")]
+        [InlineData(0, -1, 0, 0, "1073883600000000000-1073883600000000000")]
+        [InlineData(0, 0, -1, 0, "1073883600000000000-1073883600000000000")]
+        [InlineData(0, 0, 0, -1, "1073883600000000000-1073883600000000000")]
+        [InlineData(-1, -1, -1, -1, "1073883600000000000-1073883600000000000")]
+        public async Task GivenNoLastSyncStored_WhenTryGetLastSyncTime_GeneratesCorrectDataSetIdFromHistoricalImportTimeSpan(int days, int hours, int minutes, int seconds, string expectedDataSetId)
         {
-            string thirtyDaysBackDataSetId = "1071291600000000000-1073883600000000000";
+            TimeSpan timeSpan = new TimeSpan(days, hours, minutes, seconds);
+            _options.HistoricalImportTimeSpan.Returns(timeSpan);
 
             await _googleFitImportService.ProcessDatasetRequests(_googleFitUser, _dataSources, _tokensResponse, _cancellationToken);
 
             _ = _googleFitClient.Received(1).DatasetRequest(
                 Arg.Is<string>(access => access == _tokensResponse.AccessToken),
                 Arg.Is<DataSource>(ds => ds == _dataSource),
-                Arg.Is<string>(str => str == thirtyDaysBackDataSetId),
+                Arg.Is<string>(str => str == expectedDataSetId),
                 Arg.Any<int>(),
                 Arg.Is<CancellationToken>(token => token == _cancellationToken));
         }

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/GoogleFitImportServiceTests.cs
@@ -73,6 +73,7 @@ namespace FitOnFhir.GoogleFit.Tests
             _options.ParallelTaskOptions.Returns(parallelTaskOptions);
             var telemetryLogger = new GoogleFitExceptionTelemetryProcessor();
             _options.ExceptionService.Returns(telemetryLogger);
+            _options.HistoricalImportTimeSpan.Returns(TimeSpan.FromDays(30));
 
             // GoogleFitImportService dependencies
             _googleFitClient = Substitute.For<IGoogleFitClient>();

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Config/GoogleFitDataImporterConfiguration.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Config/GoogleFitDataImporterConfiguration.cs
@@ -24,5 +24,10 @@ namespace FitOnFhir.GoogleFit.Client.Config
         /// The maximum number of requests that can he handled per minute by the Google APIs.
         /// </summary>
         public int MaxRequestsPerMinute { get; set; }
+
+        /// <summary>
+        /// The period of time from now into the past, that the first Google Fit data import should cover.
+        /// </summary>
+        public TimeSpan HistoricalImportTimeSpan { get; set; }
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Config/GoogleFitImportOptions.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Config/GoogleFitImportOptions.cs
@@ -32,5 +32,7 @@ namespace FitOnFhir.GoogleFit.Client.Config
         public virtual int MaxConcurrency { get; }
 
         public virtual int MaxRequestsPerMinute { get; }
+
+        public virtual TimeSpan HistoricalImportTimeSpan { get; }
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Config/GoogleFitImportOptions.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Config/GoogleFitImportOptions.cs
@@ -21,6 +21,7 @@ namespace FitOnFhir.GoogleFit.Client.Config
             DataPointPageLimit = config.DatasetRequestLimit;
             MaxConcurrency = config.MaxConcurrency;
             MaxRequestsPerMinute = config.MaxRequestsPerMinute;
+            HistoricalImportTimeSpan = config.HistoricalImportTimeSpan;
         }
 
         public virtual ParallelTaskOptions ParallelTaskOptions { get; }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
@@ -178,6 +178,12 @@ namespace FitOnFhir.GoogleFit.Services
             DateTimeOffset currentTime = _utcNowFunc();
             long endDate = currentTime.ToUnixTimeMilliseconds() * 1000000;
 
+            // Sanity check to ensure that the starting time is not after the end, or current, time
+            if (lastSyncTimeNanos > endDate)
+            {
+                lastSyncTimeNanos = endDate;
+            }
+
             return lastSyncTimeNanos + "-" + endDate;
         }
 


### PR DESCRIPTION
Added a new environment variable to `GoogleFitImportOptions` called `HistoricalImportTimeSpan` of type `TimeSpan`.  