### PR TITLE
Fixed issue where authorization callback could not be processed

### DIFF
--- a/src/Authorization/FitOnFhir.Authorization/AuthorizationFunction.cs
+++ b/src/Authorization/FitOnFhir.Authorization/AuthorizationFunction.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using FitOnFhir.Authorization.Services;
-using FitOnFhir.Common.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
@@ -24,7 +23,6 @@ namespace FitOnFhir.Authorization
 
         public AuthorizationFunction(
             IRoutingService routingService,
-            ITokenValidationService authenticationHandler,
             ILogger<AuthorizationFunction> logger)
         {
             _routingService = EnsureArg.IsNotNull(routingService, nameof(routingService));
@@ -33,7 +31,7 @@ namespace FitOnFhir.Authorization
 
         [FunctionName("api")]
         public async Task<IActionResult> Run(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "{p1?}/{p2?}/{p3?}")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "{p1?}/{p2?}")] HttpRequest req,
             ExecutionContext context,
             CancellationToken cancellationToken)
         {

--- a/src/Authorization/FitOnFhir.Authorization/Startup.cs
+++ b/src/Authorization/FitOnFhir.Authorization/Startup.cs
@@ -37,7 +37,6 @@ namespace FitOnFhir.Authorization
         public override void Configure(IFunctionsHostBuilder builder, IConfiguration configuration)
         {
             builder.Services.AddLogging();
-            builder.Services.AddAuthentication();
             builder.Services.AddConfiguration<GoogleFitAuthorizationConfiguration>(configuration);
             builder.Services.AddConfiguration<AuthenticationConfiguration>(configuration);
             builder.Services.AddSingleton<IGoogleFitClient, GoogleFitClient>();

--- a/src/Common/FitOnFhir.Common/Config/AuthenticationConfiguration.cs
+++ b/src/Common/FitOnFhir.Common/Config/AuthenticationConfiguration.cs
@@ -7,7 +7,7 @@ namespace FitOnFhir.Common.Config
 {
     public class AuthenticationConfiguration
     {
-        private string[] _providerMetadataEndpoints;
+        private string[] _providerMetadataEndpoints = new string[] { };
 
         /// <summary>
         /// Indicates whether anonymous logins are allowed.
@@ -22,7 +22,7 @@ namespace FitOnFhir.Common.Config
         /// <summary>
         /// The list of user allowed identity providers.
         /// </summary>
-        public virtual IEnumerable<string> TokenAuthorities => _providerMetadataEndpoints;
+        public virtual IEnumerable<string> TokenAuthorities => _providerMetadataEndpoints.Any() ? _providerMetadataEndpoints : Enumerable.Empty<string>();
 
         /// <summary>
         /// A comma delimited list of the identity providers for auth token verification.

--- a/src/Common/FitOnFhir.Common/Services/TokenValidationService.cs
+++ b/src/Common/FitOnFhir.Common/Services/TokenValidationService.cs
@@ -36,7 +36,10 @@ namespace FitOnFhir.Common.Services
             _jwtSecurityTokenHandlerProvider = EnsureArg.IsNotNull(jwtSecurityTokenHandlerProvider, nameof(jwtSecurityTokenHandlerProvider));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
 
-            CreateIssuerMapping();
+            if (!_authenticationConfiguration.IsAnonymousLoginEnabled)
+            {
+                CreateIssuerMapping();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Removed `AddAuthentication()` in startup which appears to modify how query parameters (specifically 'code') are handled in Azure Functions using HttpTriggers.