### PR TITLE
Revoke user access API

### DIFF
--- a/src/Authorization/FitOnFhir.Authorization/Startup.cs
+++ b/src/Authorization/FitOnFhir.Authorization/Startup.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Threading.Tasks;
 using FitOnFhir.Authorization;
 using FitOnFhir.Authorization.Services;
@@ -45,6 +46,7 @@ namespace FitOnFhir.Authorization
             builder.Services.AddSingleton<IUsersKeyVaultRepository, UsersKeyVaultRepository>();
             builder.Services.AddSingleton<IGoogleFitUserTableRepository, GoogleFitUserTableRepository>();
             builder.Services.AddSingleton<IUsersService, UsersService>();
+            builder.Services.AddSingleton<IGoogleFitTokensService, GoogleFitTokensService>();
             builder.Services.AddSingleton<IGoogleFitAuthService, GoogleFitAuthService>();
             builder.Services.AddSingleton<IRoutingService, RoutingService>();
             builder.Services.AddHttpClient<IOpenIdConfigurationProvider, OpenIdConfigurationProvider>();
@@ -57,6 +59,7 @@ namespace FitOnFhir.Authorization
             builder.Services.AddSingleton<GoogleFitAuthorizationHandler>();
             builder.Services.AddSingleton<UnknownAuthorizationHandler>();
             builder.Services.AddSingleton<IQueueService, QueueService>();
+            builder.Services.AddSingleton(typeof(Func<DateTimeOffset>), () => DateTimeOffset.UtcNow);
             builder.Services.AddSingleton(sp => sp.CreateOrderedHandlerChain<RoutingRequest, Task<IActionResult>>(typeof(GoogleFitAuthorizationHandler), typeof(UnknownAuthorizationHandler)));
         }
     }

--- a/src/Common/FitOnFhir.Common.Tests/UsersServiceBaseTests.cs
+++ b/src/Common/FitOnFhir.Common.Tests/UsersServiceBaseTests.cs
@@ -41,6 +41,8 @@ namespace FitOnFhir.Common.Tests
 
         protected abstract Func<Task> ExecuteAuthorizationCallback { get; }
 
+        protected abstract Func<Task> ExecuteRevokeAccess { get;  }
+
         protected abstract string ExpectedPatientId { get; }
 
         protected abstract string ExpectedPatientIdentifierSystem { get; }
@@ -52,6 +54,8 @@ namespace FitOnFhir.Common.Tests
         protected abstract string ExpectedExternalPatientId { get; }
 
         protected abstract string ExpectedExternalSystem { get; }
+
+        protected abstract string ExpectedAccessToken { get;  }
 
         [Fact]
         public async Task GivenPatientAndUserDoNotExist_WhenProcessAuthorizationCallbackCalled_NewPatientAndUserCreatedAndMessageQueued()

--- a/src/Common/FitOnFhir.Common.Tests/UsersServiceBaseTests.cs
+++ b/src/Common/FitOnFhir.Common.Tests/UsersServiceBaseTests.cs
@@ -176,7 +176,7 @@ namespace FitOnFhir.Common.Tests
             };
         }
 
-        private User GetUser(string userId, string platformUserId, params (string name, DataImportState state)[] platforms)
+        protected User GetUser(string userId, string platformUserId, params (string name, DataImportState state)[] platforms)
         {
             var user = new User(Guid.Parse(userId));
 

--- a/src/Common/FitOnFhir.Common/Constants.cs
+++ b/src/Common/FitOnFhir.Common/Constants.cs
@@ -30,6 +30,11 @@ namespace FitOnFhir.Common
         public const string PatientIdQueryParameter = "patientId";
 
         /// <summary>
+        /// Query parameter name for platform user identifier in an external system.
+        /// </summary>
+        public const string UserIdQueryParameter = "userId";
+
+        /// <summary>
         /// Query parameter name for the system in which the patient identifier exists.
         /// </summary>
         public const string SystemQueryParameter = "system";

--- a/src/Common/FitOnFhir.Common/Constants.cs
+++ b/src/Common/FitOnFhir.Common/Constants.cs
@@ -30,11 +30,6 @@ namespace FitOnFhir.Common
         public const string PatientIdQueryParameter = "patientId";
 
         /// <summary>
-        /// Query parameter name for platform user identifier in an external system.
-        /// </summary>
-        public const string UserIdQueryParameter = "userId";
-
-        /// <summary>
         /// Query parameter name for the system in which the patient identifier exists.
         /// </summary>
         public const string SystemQueryParameter = "system";

--- a/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
+++ b/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
@@ -41,7 +41,11 @@ namespace FitOnFhir.Common.Models
 
         public override int GetHashCode()
         {
-            return PlatformName.GetHashCode() ^ UserId.GetHashCode() ^ ImportState.GetHashCode();
+            return PlatformName.GetHashCode() ^
+                   UserId.GetHashCode() ^
+                   ImportState.GetHashCode() ^
+                   RevokedAccessReason.GetHashCode() ^
+                   RevokedTimeStamp.GetHashCode();
         }
     }
 }

--- a/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
+++ b/src/Common/FitOnFhir.Common/Models/PlatformUserInfo.cs
@@ -25,11 +25,18 @@ namespace FitOnFhir.Common.Models
         [JsonConverter(typeof(StringEnumConverter))]
         public DataImportState ImportState { get; set; }
 
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RevokeReason RevokedAccessReason { get; set; }
+
+        public DateTimeOffset? RevokedTimeStamp { get; set; }
+
         public bool Equals(PlatformUserInfo other)
         {
             return PlatformName == other.PlatformName &&
                    UserId == other.UserId &&
-                   ImportState == other.ImportState;
+                   ImportState == other.ImportState &&
+                   RevokedAccessReason == other.RevokedAccessReason &&
+                   RevokedTimeStamp == other.RevokedTimeStamp;
         }
 
         public override int GetHashCode()

--- a/src/Common/FitOnFhir.Common/Models/RevokeReason.cs
+++ b/src/Common/FitOnFhir.Common/Models/RevokeReason.cs
@@ -1,0 +1,20 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace FitOnFhir.Common.Models
+{
+    public enum RevokeReason
+    {
+        /// <summary>
+        /// Indicates that the reason for access being revoked is not known
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// Indicates that the user requested that access be revoked
+        /// </summary>
+        UserInitiated,
+    }
+}

--- a/src/Common/FitOnFhir.Common/Requests/RequestLimiter.cs
+++ b/src/Common/FitOnFhir.Common/Requests/RequestLimiter.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using EnsureThat;
+
 namespace FitOnFhir.Common.Requests
 {
     public class RequestLimiter : IRequestLimiter
@@ -22,7 +24,7 @@ namespace FitOnFhir.Common.Requests
         {
             // If maxRequestsPerMinute is zero or a negative number, assume no throttling is required.
             _maxRequestsPerMinute = maxRequestsPerMinute > 0 ? maxRequestsPerMinute : int.MaxValue;
-            _utcNowFunc = utcNowFunc;
+            _utcNowFunc = EnsureArg.IsNotNull(utcNowFunc);
         }
 
         private DateTimeOffset ProcessStartTime { get; set; }

--- a/src/Common/FitOnFhir.Common/Services/UsersServiceBase.cs
+++ b/src/Common/FitOnFhir.Common/Services/UsersServiceBase.cs
@@ -103,9 +103,12 @@ namespace FitOnFhir.Common.Services
                 var platformInfo = user.GetPlatformUserInfo()
                     .FirstOrDefault(pui => pui.PlatformName == PlatformName);
 
-                await RevokeAccessRequest(platformInfo, cancellationToken);
+                if (platformInfo != default)
+                {
+                    await RevokeAccessRequest(platformInfo, cancellationToken);
 
-                await UpdateUser(user, cancellationToken);
+                    await UpdateUser(user, cancellationToken);
+                }
             }
         }
 

--- a/src/Common/FitOnFhir.Common/Services/UsersServiceBase.cs
+++ b/src/Common/FitOnFhir.Common/Services/UsersServiceBase.cs
@@ -114,6 +114,6 @@ namespace FitOnFhir.Common.Services
 
         public abstract Task QueueFitnessImport(User user, CancellationToken cancellationToken);
 
-        public abstract Task RevokeAccess(string userId, CancellationToken cancellationToken);
+        public abstract Task<bool> RevokeAccess(string userId, string system, CancellationToken cancellationToken);
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
@@ -8,7 +8,6 @@ using FitOnFhir.Common;
 using FitOnFhir.GoogleFit.Client.Models;
 using FitOnFhir.GoogleFit.Client.Responses;
 using Google.Apis.Fitness.v1.Data;
-using Hl7.Fhir.Model;
 using Claim = System.Security.Claims.Claim;
 
 namespace FitOnFhir.GoogleFit.Tests

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
@@ -22,14 +22,22 @@ namespace FitOnFhir.GoogleFit.Tests
         private readonly IGoogleFitUserTableRepository _googleFitUserRepository;
         private readonly IUsersKeyVaultRepository _usersKeyVaultRepository;
         private readonly IGoogleFitAuthService _authService;
+        private readonly IGoogleFitTokensService _googleFitTokensService;
+        private readonly Func<DateTimeOffset> _utcNowFunc;
         private readonly MockLogger<UsersService> _logger;
         private readonly UsersService _usersService;
+
+        private readonly DateTimeOffset _now =
+            new DateTimeOffset(2004, 1, 12, 0, 0, 0, new TimeSpan(-5, 0, 0));
 
         public UsersServiceTests()
         {
             _googleFitUserRepository = Substitute.For<IGoogleFitUserTableRepository>();
             _usersKeyVaultRepository = Substitute.For<IUsersKeyVaultRepository>();
             _authService = Substitute.For<IGoogleFitAuthService>();
+            _googleFitTokensService = Substitute.For<IGoogleFitTokensService>();
+            _utcNowFunc = Substitute.For<Func<DateTimeOffset>>();
+            _utcNowFunc().Returns(_now);
             _logger = Substitute.For<MockLogger<UsersService>>();
 
             _usersService = new UsersService(
@@ -39,6 +47,8 @@ namespace FitOnFhir.GoogleFit.Tests
                 _usersKeyVaultRepository,
                 _authService,
                 QueueService,
+                _googleFitTokensService,
+                _utcNowFunc,
                 _logger);
 
             // Default responses.

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
@@ -180,7 +180,7 @@ namespace FitOnFhir.GoogleFit.Tests
         }
 
         [Fact]
-        public async Task GivenUserForPatientExistsWithNoMatchingPlatformInfo_WhenRevokeAccessCalled_UpdatesUserWithoutRevokeReason()
+        public async Task GivenUserForPatientExistsWithNoMatchingPlatformInfo_WhenRevokeAccessCalled_DoesNotUpdateUser()
         {
             User testUser = GetUser(ExpectedPatientId, null, Array.Empty<(string name, DataImportState state)>());
             UsersTableRepository.GetById(ExpectedPatientId, Arg.Any<CancellationToken>()).Returns(testUser);
@@ -191,11 +191,8 @@ namespace FitOnFhir.GoogleFit.Tests
 
             await _authService.DidNotReceive().RevokeTokenRequest(Arg.Any<string>(), Arg.Any<CancellationToken>());
 
-            await UsersTableRepository.Received(1)
-                .Update(
-                    Arg.Is<User>(usr => usr == testUser),
-                    Arg.Is<Func<User, User, User>>(f => f == UserConflictResolvers.ResolveConflictAuthorization),
-                    Arg.Any<CancellationToken>());
+            await UsersTableRepository.DidNotReceive()
+                .Update(Arg.Any<User>(), Arg.Any<Func<User, User, User>>(), Arg.Any<CancellationToken>());
         }
 
         [Fact]

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using FitOnFhir.Common;
+using FitOnFhir.Common.Models;
 using FitOnFhir.Common.Repositories;
 using FitOnFhir.Common.Tests;
 using FitOnFhir.Common.Tests.Mocks;
@@ -57,6 +58,8 @@ namespace FitOnFhir.GoogleFit.Tests
 
         protected override Func<Task> ExecuteAuthorizationCallback => () => _usersService.ProcessAuthorizationCallback("TestAuthCode", Data.AuthorizationState, CancellationToken.None);
 
+        protected override Func<Task> ExecuteRevokeAccess => () => _usersService.RevokeAccess(new AuthState() { PatientId = ExpectedPatientId, System = ExpectedExternalSystem }, CancellationToken.None);
+
         protected override string ExpectedPatientIdentifierSystem => Data.Issuer;
 
         protected override string ExpectedPatientId => Data.PatientId;
@@ -68,6 +71,8 @@ namespace FitOnFhir.GoogleFit.Tests
         protected override string ExpectedExternalPatientId => Data.ExternalPatientId;
 
         protected override string ExpectedExternalSystem => Data.ExternalSystem;
+
+        protected override string ExpectedAccessToken => Data.AccessToken;
 
         [Fact]
         public async Task GivenAuthCodeIsNull_WhenProcessAuthorizationCallbackCalled_ExceptionIsThrown()

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
@@ -121,19 +121,21 @@ namespace FitOnFhir.GoogleFit.Client.Handlers
         private async Task<IActionResult> Revoke(RoutingRequest request)
         {
             string patientId;
+            string system;
             try
             {
                 patientId = HttpUtility.UrlDecode(EnsureArg.IsNotNullOrWhiteSpace(request?.HttpRequest?.Query?[Constants.PatientIdQueryParameter], $"query.{Constants.PatientIdQueryParameter}"));
+                system = HttpUtility.UrlDecode(EnsureArg.IsNotNullOrWhiteSpace(request?.HttpRequest?.Query?[Constants.SystemQueryParameter], $"query.{Constants.SystemQueryParameter}"));
             }
             catch (ArgumentException)
             {
-                return new BadRequestObjectResult($"'{Constants.PatientIdQueryParameter}' is a required query parameter.");
+                return new BadRequestObjectResult($"'{Constants.PatientIdQueryParameter}' and '{Constants.SystemQueryParameter}' are required query parameters.");
             }
 
             try
             {
-                await _usersService.RevokeAccess(patientId, request.Token);
-                return new OkObjectResult("Access revoked successfully.");
+                return await _usersService.RevokeAccess(patientId, system, request.Token) ?
+                    new OkObjectResult("Access revoked successfully.") : new NotFoundObjectResult("Access not revoked");
             }
             catch (Exception ex)
             {

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Common/GoogleFitConstants.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Common/GoogleFitConstants.cs
@@ -23,6 +23,11 @@ namespace FitOnFhir.GoogleFit.Common
         public const string GoogleFitCallbackRequest = "api/googlefit/callback";
 
         /// <summary>
+        /// GoogleFit revoke access endpoint
+        /// </summary>
+        public const string GoogleFitRevokeAccessRequest = "api/googlefit/revoke";
+
+        /// <summary>
         /// String identifier for the GoogleFit platform.  Used to help identify the platform to import from, in a <see cref="QueueMessage"/>.
         /// </summary>
         public const string GoogleFitPlatformName = "GoogleFit";

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitAuthService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitAuthService.cs
@@ -84,5 +84,11 @@ namespace FitOnFhir.GoogleFit.Services
             AuthTokensResponse.TryParse(tokenResponse, out AuthTokensResponse response);
             return response;
         }
+
+        /// <inheritdoc/>
+        public async Task RevokeTokenRequest(string accessToken, CancellationToken cancellationToken)
+        {
+            await _googleAuthorizationCodeFlow.RevokeTokenAsync("me", accessToken, cancellationToken);
+        }
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/GoogleFitImportService.cs
@@ -48,7 +48,7 @@ namespace FitOnFhir.GoogleFit.Services
             }
 
             _options = EnsureArg.IsNotNull(options, nameof(options));
-            _utcNowFunc = utcNowFunc;
+            _utcNowFunc = EnsureArg.IsNotNull(utcNowFunc);
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
             _telemetryLogger = EnsureArg.IsNotNull(telemetryLogger, nameof(telemetryLogger));
         }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/IAuthService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/IAuthService.cs
@@ -35,5 +35,12 @@ namespace FitOnFhir.GoogleFit.Services
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to cancel the process.</param>
         /// <returns>The <see cref="AuthTokensResponse"/> for the operation.</returns>
         Task<AuthTokensResponse> RefreshTokensRequest(string refreshToken, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Sends a token revoke request to the platform appropriate URI.
+        /// </summary>
+        /// <param name="accessToken">The access token to be revoked.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to cancel the process.</param>
+        Task RevokeTokenRequest(string accessToken, CancellationToken cancellationToken);
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
@@ -13,6 +13,6 @@ namespace FitOnFhir.GoogleFit.Services
 
         Task QueueFitnessImport(User user, CancellationToken cancellationToken);
 
-        Task RevokeAccess(string patientId, CancellationToken cancellationToken);
+        Task<bool> RevokeAccess(string patientId, string system, CancellationToken cancellationToken);
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
@@ -12,5 +12,7 @@ namespace FitOnFhir.GoogleFit.Services
         Task ProcessAuthorizationCallback(string accessCode, string state, CancellationToken cancellationToken);
 
         Task QueueFitnessImport(User user, CancellationToken cancellationToken);
+
+        Task RevokeAccess(string patientId, CancellationToken cancellationToken);
     }
 }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
@@ -3,16 +3,40 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using FitOnFhir.Common;
+using FitOnFhir.Common.Config;
 using FitOnFhir.Common.Models;
 
 namespace FitOnFhir.GoogleFit.Services
 {
     public interface IUsersService
     {
-        Task ProcessAuthorizationCallback(string accessCode, string state, CancellationToken cancellationToken);
+        /// <summary>
+        /// Method for processing the callback authorization request made by Google as the final part of authorization for a user.
+        /// Using the authorization code provided by Google, tokens (authorization, refresh, and ID) are retrieved for the user.
+        /// The ID token's subject and issuer are stored as identifiers for a patient in the FHIR server instance.
+        /// </summary>
+        /// <param name="authCode">The authorization code provided by Google and used to retrieve tokens.</param>
+        /// <param name="state">The <see cref="AuthState"/> which contains the PatientID for the user in the corresponding external medical records system.</param>
+        /// <param name="cancellationToken">The token used to cancel the operation.</param>
+        Task ProcessAuthorizationCallback(string authCode, string state, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Inserts a <see cref="QueueMessage"/> for the <see cref="User"/> into the Queue identified by the connection string in
+        /// <see cref="AzureConfiguration"/>.StorageAccountConnectionString and name contained in <see cref="Constants"/>.QueueName.
+        /// </summary>
+        /// <param name="user">The <see cref="User"/> containing the <see cref="PlatformUserInfo"/> data for the <see cref="QueueMessage"/>.</param>
+        /// <param name="cancellationToken">The token used to cancel the operation.</param>
         Task QueueFitnessImport(User user, CancellationToken cancellationToken);
 
-        Task<bool> RevokeAccess(string patientId, string system, CancellationToken cancellationToken);
+        /// <summary>
+        /// Retrieves <see cref="PlatformUserInfo"/> for the user associated with the patient in a given <see cref="AuthState"/>.
+        /// Uses this info to make a platform specific revoke access request.  Once this revoke access request is complete, updates
+        /// the <see cref="PlatformUserInfo"/> with a <see cref="RevokeReason"/> that indicates access was revoked intentionally by a user.
+        /// Also updates the <see cref="PlatformUserInfo"/> with the time stamp when this action occurred.
+        /// </summary>
+        /// <param name="state">The <see cref="AuthState"/> containing the patient ID and system.</param>
+        /// <param name="cancellationToken">The token used to cancel the operation.</param>
+        Task RevokeAccess(AuthState state, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
Created a new path (`api/googlefit/revoke`) for revoking user access.  The initial implementation of this allows for anonymous login access, where `patientId` and `system` are required as part of the request.

When a user revokes access this way, a `RevokeReason` is persisted in their `PlatformUserInfo`, along with a timestamp of when this occurred for tracking purposes.