### PR TITLE
Authorization with nonce

### DIFF
--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -34,9 +34,6 @@ param google_historical_import_time_span string = '30.00:00:00'
 @description('Enables anonymous logins (true) or requires authentication (false).')
 param authentication_anonymous_login_enabled bool = false
 
-@description('Name for the authentication data storage container.')
-param authentication_blob_container_name string = 'authdata'
-
 @description('A list of identity provider URLs used when authentication is required.')
 param authentication_identity_providers string = ''
 
@@ -45,6 +42,9 @@ param authentication_audience string = ''
 
 @description('The Google Fit data authorization scopes allowed for users of this service (see https://developers.google.com/fit/datatypes#authorization_scopes for more info)')
 param google_fit_scopes string = 'https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/userinfo.profile,https://www.googleapis.com/auth/fitness.activity.read,https://www.googleapis.com/auth/fitness.sleep.read,https://www.googleapis.com/auth/fitness.reproductive_health.read,https://www.googleapis.com/auth/fitness.oxygen_saturation.read,https://www.googleapis.com/auth/fitness.nutrition.read,https://www.googleapis.com/auth/fitness.location.read,https://www.googleapis.com/auth/fitness.body_temperature.read,https://www.googleapis.com/auth/fitness.body.read,https://www.googleapis.com/auth/fitness.blood_pressure.read,https://www.googleapis.com/auth/fitness.blood_glucose.read,https://www.googleapis.com/auth/fitness.heart_rate.read'
+
+@description('Name for the authentication data storage container.')
+param authentication_blob_container_name string = 'authdata'
 
 var fhirServiceUrl = 'https://${replace('hw-${basename}', '-', '')}-fs-${basename}.fhir.azurehealthcareapis.com'
 var fhirWriterRoleId = '3f88fce4-5892-4214-ae73-ba5294559913'

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -158,7 +158,7 @@ resource sa_basename 'Microsoft.Storage/storageAccounts@2021-02-01' = {
   }
 }
 
-resource sa_basename_default 'Microsoft.Storage/storageAccounts/blobServices@2021-04-01' = {
+resource Microsoft_Storage_storageAccounts_blobServices_sa_basename_default 'Microsoft.Storage/storageAccounts/blobServices@2021-04-01' = {
   name: '${replace('sa-${basename}', '-', '')}/default'
   properties: {
     changeFeed: {
@@ -186,9 +186,11 @@ resource sa_basename_default 'Microsoft.Storage/storageAccounts/blobServices@202
 }
 
 resource sa_basename_default_auth_state 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
+  parent: Microsoft_Storage_storageAccounts_blobServices_sa_basename_default
   name: authentication_blob_container_name
-  parent: sa_basename_default
-  properties: {}
+  properties: {
+	metadata: {}
+  }
   dependsOn: [
     sa_basename
   ]

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -158,7 +158,7 @@ resource sa_basename 'Microsoft.Storage/storageAccounts@2021-02-01' = {
   }
 }
 
-resource Microsoft_Storage_storageAccounts_blobServices_sa_basename_default 'Microsoft.Storage/storageAccounts/blobServices@2021-04-01' = {
+resource sa_basename_default 'Microsoft.Storage/storageAccounts/blobServices@2021-04-01' = {
   name: '${replace('sa-${basename}', '-', '')}/default'
   properties: {
     changeFeed: {

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -185,6 +185,14 @@ resource sa_basename_default 'Microsoft.Storage/storageAccounts/blobServices@202
   ]
 }
 
+resource sa_basename_default_blob_container 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
+  parent: sa_basename_default
+  name: authentication_blob_container_name
+  dependsOn: [
+    sa_basename
+  ]
+}
+
 resource Microsoft_Storage_storageAccounts_fileServices_sa_basename_default 'Microsoft.Storage/storageAccounts/fileServices@2021-04-01' = {
   name: '${replace('sa-${basename}', '-', '')}/default'
   properties: {}
@@ -297,7 +305,7 @@ resource authorize_basename_appsettings 'Microsoft.Web/sites/config@2015-08-01' 
   properties: {
     FUNCTIONS_EXTENSION_VERSION: '~4'
     FUNCTIONS_WORKER_RUNTIME: 'dotnet'
-    PROJECT: 'src/Authorization/FitOnFhir.Authorization/FitOnFhir.Authorization.csproj'
+    PROJECT: 'src/Authorization/FitOnFhir.Authorization/Microsoft.Health.FitOnFhir.Authorization.csproj'
 	  AzureWebJobsStorage: '@Microsoft.KeyVault(SecretUri=${reference(resourceId('Microsoft.KeyVault/vaults/secrets', 'kv-${basename}', 'storage-account-connection-string')).secretUriWithVersion})'
     AzureConfiguration__StorageAccountConnectionString: '@Microsoft.KeyVault(SecretUri=${reference(resourceId('Microsoft.KeyVault/vaults/secrets', 'kv-${basename}', 'storage-account-connection-string')).secretUriWithVersion})'
     APPINSIGHTS_INSTRUMENTATIONKEY: ai_basename.properties.InstrumentationKey
@@ -362,7 +370,7 @@ resource import_timer_basename_appsettings 'Microsoft.Web/sites/config@2015-08-0
   properties: {
     FUNCTIONS_EXTENSION_VERSION: '~4'
     FUNCTIONS_WORKER_RUNTIME: 'dotnet'
-    PROJECT: 'src/ImportTimerTrigger/FitOnFhir.ImportTimerTrigger/FitOnFhir.ImportTimerTrigger.csproj'
+    PROJECT: 'src/ImportTimerTrigger/FitOnFhir.ImportTimerTrigger/Microsoft.Health.FitOnFhir.ImportTimerTrigger.csproj'
     AzureWebJobsStorage: '@Microsoft.KeyVault(SecretUri=${reference(resourceId('Microsoft.KeyVault/vaults/secrets', 'kv-${basename}', 'storage-account-connection-string')).secretUriWithVersion})'
     AzureConfiguration__StorageAccountConnectionString: '@Microsoft.KeyVault(SecretUri=${reference(resourceId('Microsoft.KeyVault/vaults/secrets', 'kv-${basename}', 'storage-account-connection-string')).secretUriWithVersion})'
     APPINSIGHTS_INSTRUMENTATIONKEY: ai_basename.properties.InstrumentationKey
@@ -417,7 +425,7 @@ resource import_data_basename_appsettings 'Microsoft.Web/sites/config@2015-08-01
   properties: {
     FUNCTIONS_EXTENSION_VERSION: '~4'
     FUNCTIONS_WORKER_RUNTIME: 'dotnet'
-    PROJECT: 'src/Import/FitOnFhir.Import/FitOnFhir.Import.csproj'
+    PROJECT: 'src/Import/FitOnFhir.Import/Microsoft.Health.FitOnFhir.Import.csproj'
     AzureWebJobsStorage: '@Microsoft.KeyVault(SecretUri=${reference(resourceId('Microsoft.KeyVault/vaults/secrets', 'kv-${basename}', 'storage-account-connection-string')).secretUriWithVersion})'
     AzureConfiguration__StorageAccountConnectionString: '@Microsoft.KeyVault(SecretUri=${reference(resourceId('Microsoft.KeyVault/vaults/secrets', 'kv-${basename}', 'storage-account-connection-string')).secretUriWithVersion})'
     APPINSIGHTS_INSTRUMENTATIONKEY: ai_basename.properties.InstrumentationKey

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -185,17 +185,6 @@ resource Microsoft_Storage_storageAccounts_blobServices_sa_basename_default 'Mic
   ]
 }
 
-resource sa_basename_default_auth_state 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
-  parent: Microsoft_Storage_storageAccounts_blobServices_sa_basename_default
-  name: authentication_blob_container_name
-  properties: {
-	metadata: {}
-  }
-  dependsOn: [
-    sa_basename
-  ]
-}
-
 resource Microsoft_Storage_storageAccounts_fileServices_sa_basename_default 'Microsoft.Storage/storageAccounts/fileServices@2021-04-01' = {
   name: '${replace('sa-${basename}', '-', '')}/default'
   properties: {}
@@ -905,6 +894,17 @@ resource hw_basename_hi_basename_hd_basename 'Microsoft.HealthcareApis/workspace
   }
   dependsOn: [
     hw_basename
+  ]
+}
+
+resource sa_basename_default_auth_state 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
+  parent: Microsoft_Storage_storageAccounts_blobServices_sa_basename_default
+  name: authentication_blob_container_name
+  properties: {
+	metadata: {}
+  }
+  dependsOn: [
+    sa_basename
   ]
 }
 

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -193,7 +193,7 @@ resource sa_basename_default 'Microsoft.Storage/storageAccounts/blobServices@202
   ]
 }
 
-resource sa_basename_default_management_policy 'Microsoft.Storage/storageAccounts/managementPolicies@2021-04-01' = {
+resource sa_basename_default_management_policy 'Microsoft.Storage/storageAccounts/managementPolicies@2021-06-01' = {
   name: '${replace('sa-${basename}', '-', '')}/default'
   properties: {
     policy: {
@@ -203,7 +203,7 @@ resource sa_basename_default_management_policy 'Microsoft.Storage/storageAccount
             actions: {
               baseBlob: {
                 delete: {
-                  daysAfterLastAccessTimeGreaterThan: 1
+                  daysAfterModificationGreaterThan: 1
                 }
                 enableAutoTierToHotFromCool: false
               }

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -179,6 +179,50 @@ resource sa_basename_default 'Microsoft.Storage/storageAccounts/blobServices@202
       days: 7
     }
     isVersioningEnabled: false
+	lastAccessTimeTrackingPolicy: {
+      blobType: [
+        'blockBlob'
+      ]
+      enable: true
+      name: 'AccessTimeTracking'
+      trackingGranularityInDays: 1
+    }
+  }
+  dependsOn: [
+    sa_basename
+  ]
+}
+
+resource sa_basename_default_management_policy 'Microsoft.Storage/storageAccounts/managementPolicies@2021-04-01' = {
+  name: '${replace('sa-${basename}', '-', '')}/default'
+  properties: {
+    policy: {
+      rules: [
+        {
+          definition: {
+            actions: {
+              baseBlob: {
+                delete: {
+                  daysAfterLastAccessTimeGreaterThan: 1
+                }
+                enableAutoTierToHotFromCool: false
+              }
+            }
+			filters: {
+              blobTypes: [
+                'blockBlob'
+              ]
+			  prefixMatch: [
+				'${authentication_blob_container_name}/'
+			  ]
+            }
+          }
+          enabled: true
+          name: 'blob management policy'
+          type: 'Lifecycle'
+        }
+      ]
+    }
   }
   dependsOn: [
     sa_basename

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -186,7 +186,7 @@ resource sa_basename_default 'Microsoft.Storage/storageAccounts/blobServices@202
 }
 
 resource sa_basename_default_auth_state 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
-  name: 'authentication_blob_container_name'
+  name: authentication_blob_container_name
   parent: sa_basename_default
   properties: {
     publicAccess: 'None'

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -188,9 +188,7 @@ resource sa_basename_default 'Microsoft.Storage/storageAccounts/blobServices@202
 resource sa_basename_default_auth_state 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
   name: authentication_blob_container_name
   parent: sa_basename_default
-  properties: {
-    publicAccess: 'None'
-  }
+  properties: {}
   dependsOn: [
     sa_basename
   ]

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -897,17 +897,6 @@ resource hw_basename_hi_basename_hd_basename 'Microsoft.HealthcareApis/workspace
   ]
 }
 
-resource sa_basename_default_auth_state 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
-  parent: Microsoft_Storage_storageAccounts_blobServices_sa_basename_default
-  name: authentication_blob_container_name
-  properties: {
-	metadata: {}
-  }
-  dependsOn: [
-    sa_basename
-  ]
-}
-
 output authorizeAppName string = 'authorize-${basename}'
 output importTimerAppName string = 'import-timer-${basename}'
 output importDataAppName string = 'import-data-${basename}'

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.8.9.13224",
-      "templateHash": "15638335300315121251"
+      "templateHash": "2702093357060843998"
     }
   },
   "parameters": {
@@ -83,6 +83,13 @@
       "defaultValue": false,
       "metadata": {
         "description": "Enables anonymous logins (true) or requires authentication (false)."
+      }
+    },
+    "authentication_blob_container_name": {
+      "type": "string",
+      "defaultValue": "authdata",
+      "metadata": {
+        "description": "Name for the authentication data storage container."
       }
     },
     "authentication_identity_providers": {
@@ -268,6 +275,18 @@
       ]
     },
     {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2021-04-01",
+      "name": "[format('{0}/{1}/{2}', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1], 'authentication_blob_container_name')]",
+      "properties": {
+        "publicAccess": "None"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]",
+        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1])]"
+      ]
+    },
+    {
       "type": "Microsoft.Storage/storageAccounts/fileServices",
       "apiVersion": "2021-04-01",
       "name": "[format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', ''))]",
@@ -406,6 +425,7 @@
         "GoogleFitAuthorizationConfiguration__ClientSecret": "[format('@Microsoft.KeyVault(SecretUri={0})', reference(resourceId('Microsoft.KeyVault/vaults/secrets', format('kv-{0}', parameters('basename')), 'google-client-secret')).secretUriWithVersion)]",
         "GoogleFitAuthorizationConfiguration__Scopes": "[parameters('google_fit_scopes')]",
         "AzureConfiguration__UsersKeyVaultUri": "[format('https://kv-{0}{1}', parameters('basename'), environment().suffixes.keyvaultDns)]",
+        "AzureConfiguration__BlobContainerName": "[parameters('authentication_blob_container_name')]",
         "AuthenticationConfiguration__IsAnonymousLoginEnabled": "[if(equals(parameters('authentication_anonymous_login_enabled'), true()), 'true', 'false')]",
         "AuthenticationConfiguration__IdentityProviders": "[if(equals(parameters('authentication_anonymous_login_enabled'), true()), '', parameters('authentication_identity_providers'))]",
         "AuthenticationConfiguration__Audience": "[if(equals(parameters('authentication_anonymous_login_enabled'), true()), '', parameters('authentication_audience'))]",

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.8.9.13224",
-      "templateHash": "6783489085274077225"
+      "templateHash": "12429358091584368469"
     }
   },
   "parameters": {
@@ -278,10 +278,12 @@
       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
       "apiVersion": "2021-04-01",
       "name": "[format('{0}/{1}/{2}', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1], parameters('authentication_blob_container_name'))]",
-      "properties": {},
+      "properties": {
+        "metadata": {}
+      },
       "dependsOn": [
-        "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]",
-        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1])]"
+        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1])]",
+        "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]"
       ]
     },
     {

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.9.1.41621",
-      "templateHash": "13086339191595245439"
+      "templateHash": "13975702932902341415"
     }
   },
   "parameters": {
@@ -268,7 +268,52 @@
           "enabled": true,
           "days": 7
         },
-        "isVersioningEnabled": false
+        "isVersioningEnabled": false,
+        "lastAccessTimeTrackingPolicy": {
+          "blobType": [
+            "blockBlob"
+          ],
+          "enable": true,
+          "name": "AccessTimeTracking",
+          "trackingGranularityInDays": 1
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+      "apiVersion": "2021-04-01",
+      "name": "[format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', ''))]",
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterLastAccessTimeGreaterThan": 1
+                    },
+                    "enableAutoTierToHotFromCool": false
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "[format('{0}/', parameters('authentication_blob_container_name'))]"
+                  ]
+                }
+              },
+              "enabled": true,
+              "name": "blob management policy",
+              "type": "Lifecycle"
+            }
+          ]
+        }
       },
       "dependsOn": [
         "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]"

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.8.9.13224",
-      "templateHash": "2702093357060843998"
+      "templateHash": "945698026806621114"
     }
   },
   "parameters": {
@@ -277,7 +277,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
       "apiVersion": "2021-04-01",
-      "name": "[format('{0}/{1}/{2}', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1], 'authentication_blob_container_name')]",
+      "name": "[format('{0}/{1}/{2}', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1], parameters('authentication_blob_container_name'))]",
       "properties": {
         "publicAccess": "None"
       },

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.8.9.13224",
-      "templateHash": "945698026806621114"
+      "templateHash": "6769424909127961088"
     }
   },
   "parameters": {
@@ -85,13 +85,6 @@
         "description": "Enables anonymous logins (true) or requires authentication (false)."
       }
     },
-    "authentication_blob_container_name": {
-      "type": "string",
-      "defaultValue": "authdata",
-      "metadata": {
-        "description": "Name for the authentication data storage container."
-      }
-    },
     "authentication_identity_providers": {
       "type": "string",
       "defaultValue": "",
@@ -111,6 +104,13 @@
       "defaultValue": "https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/userinfo.profile,https://www.googleapis.com/auth/fitness.activity.read,https://www.googleapis.com/auth/fitness.sleep.read,https://www.googleapis.com/auth/fitness.reproductive_health.read,https://www.googleapis.com/auth/fitness.oxygen_saturation.read,https://www.googleapis.com/auth/fitness.nutrition.read,https://www.googleapis.com/auth/fitness.location.read,https://www.googleapis.com/auth/fitness.body_temperature.read,https://www.googleapis.com/auth/fitness.body.read,https://www.googleapis.com/auth/fitness.blood_pressure.read,https://www.googleapis.com/auth/fitness.blood_glucose.read,https://www.googleapis.com/auth/fitness.heart_rate.read",
       "metadata": {
         "description": "The Google Fit data authorization scopes allowed for users of this service (see https://developers.google.com/fit/datatypes#authorization_scopes for more info)"
+      }
+    },
+    "authentication_blob_container_name": {
+      "type": "string",
+      "defaultValue": "authdata",
+      "metadata": {
+        "description": "Name for the authentication data storage container."
       }
     }
   },

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.8.9.13224",
-      "templateHash": "14382847576739928189"
+      "version": "0.9.1.41621",
+      "templateHash": "13086339191595245439"
     }
   },
   "parameters": {
@@ -275,6 +275,15 @@
       ]
     },
     {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2021-04-01",
+      "name": "[format('{0}/{1}/{2}', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1], parameters('authentication_blob_container_name'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]",
+        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1])]"
+      ]
+    },
+    {
       "type": "Microsoft.Storage/storageAccounts/fileServices",
       "apiVersion": "2021-04-01",
       "name": "[format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', ''))]",
@@ -402,7 +411,7 @@
       "properties": {
         "FUNCTIONS_EXTENSION_VERSION": "~4",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-        "PROJECT": "src/Authorization/FitOnFhir.Authorization/FitOnFhir.Authorization.csproj",
+        "PROJECT": "src/Authorization/FitOnFhir.Authorization/Microsoft.Health.FitOnFhir.Authorization.csproj",
         "AzureWebJobsStorage": "[format('@Microsoft.KeyVault(SecretUri={0})', reference(resourceId('Microsoft.KeyVault/vaults/secrets', format('kv-{0}', parameters('basename')), 'storage-account-connection-string')).secretUriWithVersion)]",
         "AzureConfiguration__StorageAccountConnectionString": "[format('@Microsoft.KeyVault(SecretUri={0})', reference(resourceId('Microsoft.KeyVault/vaults/secrets', format('kv-{0}', parameters('basename')), 'storage-account-connection-string')).secretUriWithVersion)]",
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', format('ai-{0}', parameters('basename')))).InstrumentationKey]",
@@ -474,7 +483,7 @@
       "properties": {
         "FUNCTIONS_EXTENSION_VERSION": "~4",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-        "PROJECT": "src/ImportTimerTrigger/FitOnFhir.ImportTimerTrigger/FitOnFhir.ImportTimerTrigger.csproj",
+        "PROJECT": "src/ImportTimerTrigger/FitOnFhir.ImportTimerTrigger/Microsoft.Health.FitOnFhir.ImportTimerTrigger.csproj",
         "AzureWebJobsStorage": "[format('@Microsoft.KeyVault(SecretUri={0})', reference(resourceId('Microsoft.KeyVault/vaults/secrets', format('kv-{0}', parameters('basename')), 'storage-account-connection-string')).secretUriWithVersion)]",
         "AzureConfiguration__StorageAccountConnectionString": "[format('@Microsoft.KeyVault(SecretUri={0})', reference(resourceId('Microsoft.KeyVault/vaults/secrets', format('kv-{0}', parameters('basename')), 'storage-account-connection-string')).secretUriWithVersion)]",
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', format('ai-{0}', parameters('basename')))).InstrumentationKey]",
@@ -536,7 +545,7 @@
       "properties": {
         "FUNCTIONS_EXTENSION_VERSION": "~4",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-        "PROJECT": "src/Import/FitOnFhir.Import/FitOnFhir.Import.csproj",
+        "PROJECT": "src/Import/FitOnFhir.Import/Microsoft.Health.FitOnFhir.Import.csproj",
         "AzureWebJobsStorage": "[format('@Microsoft.KeyVault(SecretUri={0})', reference(resourceId('Microsoft.KeyVault/vaults/secrets', format('kv-{0}', parameters('basename')), 'storage-account-connection-string')).secretUriWithVersion)]",
         "AzureConfiguration__StorageAccountConnectionString": "[format('@Microsoft.KeyVault(SecretUri={0})', reference(resourceId('Microsoft.KeyVault/vaults/secrets', format('kv-{0}', parameters('basename')), 'storage-account-connection-string')).secretUriWithVersion)]",
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', format('ai-{0}', parameters('basename')))).InstrumentationKey]",

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.8.9.13224",
-      "templateHash": "12429358091584368469"
+      "templateHash": "11466565687152666044"
     }
   },
   "parameters": {
@@ -271,18 +271,6 @@
         "isVersioningEnabled": false
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-      "apiVersion": "2021-04-01",
-      "name": "[format('{0}/{1}/{2}', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1], parameters('authentication_blob_container_name'))]",
-      "properties": {
-        "metadata": {}
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1])]",
         "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]"
       ]
     },
@@ -1058,6 +1046,18 @@
         "[resourceId('Microsoft.HealthcareApis/workspaces', replace(format('hw-{0}', parameters('basename')), '-', ''))]",
         "[resourceId('Microsoft.HealthcareApis/workspaces/fhirservices', split(format('{0}/fs-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[0], split(format('{0}/fs-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[1])]",
         "[resourceId('Microsoft.HealthcareApis/workspaces/iotconnectors', split(format('{0}/hi-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[0], split(format('{0}/hi-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[1])]"
+      ]
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2021-04-01",
+      "name": "[format('{0}/{1}/{2}', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1], parameters('authentication_blob_container_name'))]",
+      "properties": {
+        "metadata": {}
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1])]",
+        "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]"
       ]
     }
   ],

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.8.9.13224",
-      "templateHash": "6769424909127961088"
+      "templateHash": "6783489085274077225"
     }
   },
   "parameters": {
@@ -278,9 +278,7 @@
       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
       "apiVersion": "2021-04-01",
       "name": "[format('{0}/{1}/{2}', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1], parameters('authentication_blob_container_name'))]",
-      "properties": {
-        "publicAccess": "None"
-      },
+      "properties": {},
       "dependsOn": [
         "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]",
         "[resourceId('Microsoft.Storage/storageAccounts/blobServices', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1])]"

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.9.1.41621",
-      "templateHash": "13975702932902341415"
+      "templateHash": "7739926137165311584"
     }
   },
   "parameters": {
@@ -284,7 +284,7 @@
     },
     {
       "type": "Microsoft.Storage/storageAccounts/managementPolicies",
-      "apiVersion": "2021-04-01",
+      "apiVersion": "2021-06-01",
       "name": "[format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', ''))]",
       "properties": {
         "policy": {
@@ -294,7 +294,7 @@
                 "actions": {
                   "baseBlob": {
                     "delete": {
-                      "daysAfterLastAccessTimeGreaterThan": 1
+                      "daysAfterModificationGreaterThan": 1
                     },
                     "enableAutoTierToHotFromCool": false
                   }

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.8.9.13224",
-      "templateHash": "11466565687152666044"
+      "templateHash": "14382847576739928189"
     }
   },
   "parameters": {
@@ -1046,18 +1046,6 @@
         "[resourceId('Microsoft.HealthcareApis/workspaces', replace(format('hw-{0}', parameters('basename')), '-', ''))]",
         "[resourceId('Microsoft.HealthcareApis/workspaces/fhirservices', split(format('{0}/fs-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[0], split(format('{0}/fs-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[1])]",
         "[resourceId('Microsoft.HealthcareApis/workspaces/iotconnectors', split(format('{0}/hi-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[0], split(format('{0}/hi-{1}', replace(format('hw-{0}', parameters('basename')), '-', ''), parameters('basename')), '/')[1])]"
-      ]
-    },
-    {
-      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-      "apiVersion": "2021-04-01",
-      "name": "[format('{0}/{1}/{2}', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1], parameters('authentication_blob_container_name'))]",
-      "properties": {
-        "metadata": {}
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[0], split(format('{0}/default', replace(format('sa-{0}', parameters('basename')), '-', '')), '/')[1])]",
-        "[resourceId('Microsoft.Storage/storageAccounts', replace(format('sa-{0}', parameters('basename')), '-', ''))]"
       ]
     }
   ],

--- a/src/Common/FitOnFhir.Common.Tests/AuthStateServiceTests.cs
+++ b/src/Common/FitOnFhir.Common.Tests/AuthStateServiceTests.cs
@@ -4,7 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.IdentityModel.Tokens.Jwt;
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.FitOnFhir.Common.Config;
 using Microsoft.Health.FitOnFhir.Common.Services;
 using Microsoft.Health.FitOnFhir.Common.Tests.Mocks;
 using NSubstitute;
@@ -14,6 +16,8 @@ namespace Microsoft.Health.FitOnFhir.Common.Tests
 {
     public class AuthStateServiceTests : AuthenticationBaseTests
     {
+        private readonly AzureConfiguration _azureConfiguration;
+        private readonly BlobServiceClient _blobServiceClient;
         private readonly MockLogger<AuthStateService> _logger;
         private readonly AuthStateService _authStateService;
 
@@ -22,8 +26,15 @@ namespace Microsoft.Health.FitOnFhir.Common.Tests
             SetupConfiguration(false);
 
             // create new service for testing
+            _azureConfiguration = Substitute.For<AzureConfiguration>();
+            _blobServiceClient = Substitute.For<BlobServiceClient>();
             _logger = Substitute.For<MockLogger<AuthStateService>>();
-            _authStateService = new AuthStateService(AuthConfiguration, SecurityTokenHandlerProvider, _logger);
+            _authStateService = new AuthStateService(
+                _azureConfiguration,
+                AuthConfiguration,
+                SecurityTokenHandlerProvider,
+                _blobServiceClient,
+                _logger);
         }
 
         [Fact]

--- a/src/Common/FitOnFhir.Common.Tests/AuthStateServiceTests.cs
+++ b/src/Common/FitOnFhir.Common.Tests/AuthStateServiceTests.cs
@@ -4,18 +4,28 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.IdentityModel.Tokens.Jwt;
+using Azure;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.FitOnFhir.Common.Config;
+using Microsoft.Health.FitOnFhir.Common.Models;
 using Microsoft.Health.FitOnFhir.Common.Services;
 using Microsoft.Health.FitOnFhir.Common.Tests.Mocks;
+using Newtonsoft.Json;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Microsoft.Health.FitOnFhir.Common.Tests
 {
-    public class AuthStateServiceTests : AuthenticationBaseTests
+    public class AuthStateServiceTests : AuthenticationBaseTests, IDisposable
     {
+        private BlobContainerClient _blobContainerClient;
+        private BlobClient _blobClient;
+        private BlobDownloadInfo _blobDownloadInfo;
+        private Stream _authStateStream;
+        private StreamWriter _authStateWriter;
         private readonly AzureConfiguration _azureConfiguration;
         private readonly BlobServiceClient _blobServiceClient;
         private readonly MockLogger<AuthStateService> _logger;
@@ -29,6 +39,7 @@ namespace Microsoft.Health.FitOnFhir.Common.Tests
             _azureConfiguration = Substitute.For<AzureConfiguration>();
             _blobServiceClient = Substitute.For<BlobServiceClient>();
             _logger = Substitute.For<MockLogger<AuthStateService>>();
+            SetupBlobSubstitutes();
             _authStateService = new AuthStateService(
                 _azureConfiguration,
                 AuthConfiguration,
@@ -36,6 +47,14 @@ namespace Microsoft.Health.FitOnFhir.Common.Tests
                 _blobServiceClient,
                 _logger);
         }
+
+        protected string ExpectedBlobContainerName => "BlobContainerName";
+
+        protected string ExpectedNonce => "Nonce";
+
+        protected string AuthorizationState => $"{{\"{Constants.ExternalIdQueryParameter}\":\"{ExpectedExternalIdentifier}\", \"{Constants.ExternalSystemQueryParameter}\":\"{ExpectedExternalSystem}\"}}";
+
+        protected AuthState StoredAuthState => JsonConvert.DeserializeObject<AuthState>(AuthorizationState);
 
         [Fact]
         public void GivenAnonymousLoginEnabledWithValidRequest_WhenCreateAuthStateCalled_ReturnsAuthStateWithQueryParams()
@@ -97,6 +116,134 @@ namespace Microsoft.Health.FitOnFhir.Common.Tests
             var authState = _authStateService.CreateAuthState(Request);
 
             Assert.Null(authState);
+        }
+
+        [Fact]
+        public async Task GivenNonceIsNull_WhenRetrieveAuthStateIsCalled_ThrowsNullException()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _authStateService.RetrieveAuthState(null, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task GivenNonceIsEmpty_WhenRetrieveAuthStateIsCalled_ThrowsNullException()
+        {
+            await Assert.ThrowsAsync<ArgumentException>(() => _authStateService.RetrieveAuthState(string.Empty, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task GivenGetBlobClientThrowsException_WhenRetrieveAuthStateIsCalled_ThrowsException()
+        {
+            string exceptionMessage = "GetBlobClient exception";
+            var exception = new Exception(exceptionMessage);
+
+            _blobContainerClient.GetBlobClient(Arg.Is<string>(str => str == ExpectedNonce)).Throws(exception);
+            await Assert.ThrowsAsync<Exception>(() => _authStateService.RetrieveAuthState(ExpectedNonce, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task GivenDownloadAsyncThrowsException_WhenRetrieveAuthStateIsCalled_ThrowsException()
+        {
+            string exceptionMessage = "DownloadAsync exception";
+            var exception = new Exception(exceptionMessage);
+
+            _blobClient.DownloadAsync(Arg.Any<CancellationToken>()).Throws(exception);
+            await Assert.ThrowsAsync<Exception>(() => _authStateService.RetrieveAuthState(ExpectedNonce, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task GivenNonceIsValid_WhenRetrieveAuthStateIsCalled_RetrunsStoredAuthState()
+        {
+            var authState = await _authStateService.RetrieveAuthState(ExpectedNonce, CancellationToken.None);
+            Assert.Equal(ExpectedExternalIdentifier, authState.ExternalIdentifier);
+            Assert.Equal(ExpectedExternalSystem, authState.ExternalSystem);
+        }
+
+        [Fact]
+        public async Task GivenGetBlobClientThrowsException_WhenStoreAuthStateIsCalled_ExceptionIsLoggedAndNullIsReturned()
+        {
+            string exceptionMessage = "Failed to store the auth state.";
+            var exception = new Exception(exceptionMessage);
+
+            _blobContainerClient.GetBlobClient(Arg.Any<string>()).Throws(exception);
+
+            var nonce = await _authStateService.StoreAuthState(StoredAuthState, CancellationToken.None);
+
+            _logger.Received(1).Log(
+                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Error),
+                Arg.Any<Exception>(),
+                Arg.Is<string>(msg => msg == exceptionMessage));
+            Assert.Null(nonce);
+        }
+
+        [Fact]
+        public async Task GivenUploadAsyncThrowsException_WhenStoreAuthStateIsCalled_ExceptionIsLoggedAndNullIsReturned()
+        {
+            string exceptionMessage = "Failed to store the auth state.";
+            var exception = new Exception(exceptionMessage);
+
+            _blobContainerClient.GetBlobClient(Arg.Any<string>()).Returns(_blobClient);
+            _blobClient.UploadAsync(
+                Arg.Any<BinaryData>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>()).Throws(exception);
+
+            var nonce = await _authStateService.StoreAuthState(StoredAuthState, CancellationToken.None);
+
+            _logger.Received(1).Log(
+                Arg.Is<LogLevel>(lvl => lvl == LogLevel.Error),
+                Arg.Any<Exception>(),
+                Arg.Is<string>(msg => msg == exceptionMessage));
+            Assert.Null(nonce);
+        }
+
+        [Fact]
+        public async Task GivenAuthStateIsValid_WhenStoreAuthStateIsCalled_UploadAsyncIsCalled()
+        {
+            _blobContainerClient.GetBlobClient(Arg.Any<string>()).Returns(_blobClient);
+            var nonce = await _authStateService.StoreAuthState(StoredAuthState, CancellationToken.None);
+
+            await _blobClient.Received(1).UploadAsync(
+                Arg.Any<BinaryData>(),
+                Arg.Is<bool>(b => b == true),
+                Arg.Any<CancellationToken>());
+
+            // verify nonce length is 24 chars
+            Assert.Equal(24, nonce.Length);
+        }
+
+        private void SetupBlobSubstitutes()
+        {
+            _azureConfiguration.BlobContainerName = ExpectedBlobContainerName;
+
+            _blobContainerClient = Substitute.For<BlobContainerClient>();
+            _blobServiceClient.GetBlobContainerClient(Arg.Is<string>(str => str == ExpectedBlobContainerName))
+                .Returns(_blobContainerClient);
+
+            _blobClient = Substitute.For<BlobClient>();
+            _blobContainerClient.GetBlobClient(Arg.Is<string>(str => str == ExpectedNonce)).Returns(_blobClient);
+
+            _authStateStream = BuildAuthStream(AuthorizationState);
+            _blobDownloadInfo = BlobsModelFactory.BlobDownloadInfo(content: _authStateStream);
+            var blobDownloadInfoResponse = Substitute.For<Response<BlobDownloadInfo>>();
+            blobDownloadInfoResponse.Value.Returns(_blobDownloadInfo);
+
+            _blobClient.DownloadAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Response<BlobDownloadInfo>>(blobDownloadInfoResponse));
+        }
+
+        private Stream BuildAuthStream(string serializedAuthState)
+        {
+            var stream = new MemoryStream();
+            _authStateWriter = new StreamWriter(stream);
+            _authStateWriter.Write(serializedAuthState);
+            _authStateWriter.Flush();
+            stream.Position = 0;
+            return stream;
+        }
+
+        public void Dispose()
+        {
+            _authStateStream.Dispose();
+            _authStateWriter.Dispose();
         }
     }
 }

--- a/src/Common/FitOnFhir.Common/Config/AzureConfiguration.cs
+++ b/src/Common/FitOnFhir.Common/Config/AzureConfiguration.cs
@@ -12,5 +12,7 @@ namespace Microsoft.Health.FitOnFhir.Common.Config
         public string UsersKeyVaultUri { get; set; }
 
         public string EventHubConnectionString { get; set; }
+
+        public string BlobContainerName { get; set; }
     }
 }

--- a/src/Common/FitOnFhir.Common/Constants.cs
+++ b/src/Common/FitOnFhir.Common/Constants.cs
@@ -33,5 +33,20 @@ namespace Microsoft.Health.FitOnFhir.Common
         /// Query parameter name for the system in which the patient identifier exists.
         /// </summary>
         public const string ExternalSystemQueryParameter = "externalSystem";
+
+        /// <summary>
+        /// The name of the container in blob storage that holds the temporary authorization credentials.
+        /// </summary>
+        public const string BlobStorageContainerName = "FitOnFhirAuthStorage";
+
+        /// <summary>
+        /// The name of the blob containing the authorization credentials.
+        /// </summary>
+        public const string BlobName = "FitOnFhirAuthBlob";
+
+        /// <summary>
+        /// The length of a generated nonce.
+        /// </summary>
+        public const int NonceLength = 24;
     }
 }

--- a/src/Common/FitOnFhir.Common/Constants.cs
+++ b/src/Common/FitOnFhir.Common/Constants.cs
@@ -48,5 +48,10 @@ namespace Microsoft.Health.FitOnFhir.Common
         /// The length of a generated nonce.
         /// </summary>
         public const int NonceLength = 24;
+
+        /// <summary>
+        /// The amount of time that an AuthState instance can be used to authorize with, from the time it is created.
+        /// </summary>
+        public static readonly TimeSpan AuthStateExpiry = TimeSpan.FromMinutes(5);
     }
 }

--- a/src/Common/FitOnFhir.Common/Interfaces/IAuthStateService.cs
+++ b/src/Common/FitOnFhir.Common/Interfaces/IAuthStateService.cs
@@ -22,5 +22,22 @@ namespace Microsoft.Health.FitOnFhir.Common.Interfaces
         /// Will throw an <see cref="ArgumentException"/> if <see cref="AuthenticationConfiguration.IsAnonymousLoginEnabled"/> is false and
         /// query params <see cref="Constants.ExternalIdQueryParameter"/> and <see cref="Constants.ExternalSystemQueryParameter"/> are present in the <see cref="HttpRequest"/>.</returns>
         AuthState CreateAuthState(HttpRequest httpRequest);
+
+        /// <summary>
+        /// Stores an <see cref="AuthState"/> as a blob under a generated nonce name.
+        /// The generated nonce returned is used later on for retrieval of the AuthState data.
+        /// </summary>
+        /// <param name="state">The <see cref="AuthState"/> to store.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to cancel the process.</param>
+        /// <returns>The generated nonce which the <see cref="AuthState"/> is stored under.</returns>
+        Task<string> StoreAuthState(AuthState state, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves stored <see cref="AuthState"/> data from a blob, as identified by the provided nonce.
+        /// </summary>
+        /// <param name="nonce">The nonce which the blob is named after.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to cancel the process.</param>
+        /// <returns>The <see cref="AuthState"/> stored in the blob specified by the provided nonce.</returns>
+        Task<AuthState> RetrieveAuthState(string nonce, CancellationToken cancellationToken);
     }
 }

--- a/src/Common/FitOnFhir.Common/Microsoft.Health.FitOnFhir.Common.csproj
+++ b/src/Common/FitOnFhir.Common/Microsoft.Health.FitOnFhir.Common.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.5.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />

--- a/src/Common/FitOnFhir.Common/Models/AuthState.cs
+++ b/src/Common/FitOnFhir.Common/Models/AuthState.cs
@@ -16,10 +16,11 @@ namespace Microsoft.Health.FitOnFhir.Common.Models
         {
         }
 
-        public AuthState(string externalIdentifier, string externalSystem)
+        public AuthState(string externalIdentifier, string externalSystem, DateTimeOffset expirationTimeStamp)
         {
             ExternalIdentifier = EnsureArg.IsNotEmptyOrWhiteSpace(externalIdentifier, nameof(externalIdentifier));
             ExternalSystem = EnsureArg.IsNotEmptyOrWhiteSpace(externalSystem, nameof(externalSystem));
+            ExpirationTimeStamp = expirationTimeStamp;
         }
 
         [JsonProperty(Constants.ExternalIdQueryParameter)]
@@ -32,12 +33,16 @@ namespace Microsoft.Health.FitOnFhir.Common.Models
         [JsonRequired]
         public string ExternalSystem { get; set; }
 
+        public DateTimeOffset ExpirationTimeStamp { get; set; }
+
         public static AuthState Parse(string jsonString)
         {
             EnsureArg.IsNotNullOrWhiteSpace(jsonString, nameof(jsonString));
             AuthState authState = JsonConvert.DeserializeObject<AuthState>(jsonString);
 
-            if (string.IsNullOrEmpty(authState.ExternalIdentifier) || string.IsNullOrEmpty(authState.ExternalSystem))
+            if (string.IsNullOrEmpty(authState.ExternalIdentifier) ||
+                string.IsNullOrEmpty(authState.ExternalSystem) ||
+                authState.ExpirationTimeStamp == default)
             {
                 throw new ArgumentException();
             }

--- a/src/Common/FitOnFhir.Common/Services/AuthStateService.cs
+++ b/src/Common/FitOnFhir.Common/Services/AuthStateService.cs
@@ -3,8 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.IdentityModel.Tokens.Jwt;
+using System.Text;
 using System.Web;
+using Azure.Storage.Blobs;
 using EnsureThat;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
@@ -13,20 +14,37 @@ using Microsoft.Health.FitOnFhir.Common.Config;
 using Microsoft.Health.FitOnFhir.Common.ExtensionMethods;
 using Microsoft.Health.FitOnFhir.Common.Interfaces;
 using Microsoft.Health.FitOnFhir.Common.Models;
+using Newtonsoft.Json;
 
 namespace Microsoft.Health.FitOnFhir.Common.Services
 {
     public class AuthStateService : IAuthStateService
     {
+        private string _base36Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        private Random _random = new Random();
+        private BlobContainerClient _blobContainerClient;
+        private BlobServiceClient _blobServiceClient;
         private readonly AuthenticationConfiguration _authenticationConfiguration;
         private readonly IJwtSecurityTokenHandlerProvider _jwtSecurityTokenHandlerProvider;
         private readonly ILogger _logger;
 
         public AuthStateService(
+            AzureConfiguration azureConfiguration,
             AuthenticationConfiguration authenticationConfiguration,
             IJwtSecurityTokenHandlerProvider jwtSecurityTokenHandlerProvider,
+            BlobServiceClient blobServiceClient,
             ILogger<AuthStateService> logger)
         {
+            if (blobServiceClient == null)
+            {
+                _blobServiceClient = new BlobServiceClient(azureConfiguration.StorageAccountConnectionString);
+            }
+            else
+            {
+                _blobServiceClient = blobServiceClient;
+            }
+
+            _blobContainerClient = _blobServiceClient.GetBlobContainerClient(azureConfiguration.BlobContainerName);
             _authenticationConfiguration = EnsureArg.IsNotNull(authenticationConfiguration, nameof(authenticationConfiguration));
             _jwtSecurityTokenHandlerProvider = EnsureArg.IsNotNull(jwtSecurityTokenHandlerProvider, nameof(jwtSecurityTokenHandlerProvider));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
@@ -80,6 +98,60 @@ namespace Microsoft.Health.FitOnFhir.Common.Services
             }
 
             return new AuthState(ExternalIdentifier, ExternalSystem);
+        }
+
+        public async Task<AuthState> RetrieveAuthState(string nonce, CancellationToken cancellationToken)
+        {
+            try
+            {
+                // Get a reference to the blob
+                BlobClient blobClient = _blobContainerClient.GetBlobClient(nonce);
+
+                // Get the AuthState
+                var response = await blobClient.DownloadAsync(cancellationToken);
+
+                // deserialize the AuthState
+                StreamReader reader = new StreamReader(response.Value.Content);
+                string json = reader.ReadToEnd();
+                return AuthState.Parse(json);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve the auth state.");
+                throw;
+            }
+        }
+
+        public async Task<string> StoreAuthState(AuthState state, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var nonce = GenerateNonce(Constants.NonceLength);
+
+                // Get a reference to the blob
+                BlobClient blobClient = _blobContainerClient.GetBlobClient(nonce);
+
+                // store state to blob storage
+                await blobClient.UploadAsync(new BinaryData(JsonConvert.SerializeObject(state)), true, cancellationToken);
+
+                return nonce;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to store the auth state.");
+                return null;
+            }
+        }
+
+        private string GenerateNonce(int length)
+        {
+            var nonce = new StringBuilder();
+            for (var i = 0; i < length; i++)
+            {
+                nonce.Append(_base36Chars[_random.Next(0, _base36Chars.Length - 1)]);
+            }
+
+            return nonce.ToString();
         }
     }
 }

--- a/src/Common/FitOnFhir.Common/Services/AuthStateService.cs
+++ b/src/Common/FitOnFhir.Common/Services/AuthStateService.cs
@@ -6,6 +6,7 @@
 using System.Text;
 using System.Web;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using EnsureThat;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
@@ -130,6 +131,9 @@ namespace Microsoft.Health.FitOnFhir.Common.Services
 
                 // Get a reference to the blob
                 BlobClient blobClient = _blobContainerClient.GetBlobClient(nonce);
+
+                // Set the CacheControl property to expire in 5 minutes (300 seconds)
+                await blobClient.SetHttpHeadersAsync(new BlobHttpHeaders { CacheControl = "max-age=300" }, cancellationToken: cancellationToken);
 
                 // store state to blob storage
                 await blobClient.UploadAsync(new BinaryData(JsonConvert.SerializeObject(state)), true, cancellationToken);

--- a/src/Common/FitOnFhir.Common/Services/AuthStateService.cs
+++ b/src/Common/FitOnFhir.Common/Services/AuthStateService.cs
@@ -9,7 +9,6 @@ using Azure.Storage.Blobs;
 using EnsureThat;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.FitOnFhir.Common.Config;
 using Microsoft.Health.FitOnFhir.Common.ExtensionMethods;
@@ -27,7 +26,6 @@ namespace Microsoft.Health.FitOnFhir.Common.Services
         private BlobServiceClient _blobServiceClient;
         private readonly AuthenticationConfiguration _authenticationConfiguration;
         private readonly IJwtSecurityTokenHandlerProvider _jwtSecurityTokenHandlerProvider;
-        private HttpClient _httpClient;
         private readonly ILogger _logger;
 
         public AuthStateService(
@@ -35,7 +33,6 @@ namespace Microsoft.Health.FitOnFhir.Common.Services
             AuthenticationConfiguration authenticationConfiguration,
             IJwtSecurityTokenHandlerProvider jwtSecurityTokenHandlerProvider,
             BlobServiceClient blobServiceClient,
-            HttpClient httpClient,
             ILogger<AuthStateService> logger)
         {
             if (blobServiceClient == null)
@@ -53,7 +50,6 @@ namespace Microsoft.Health.FitOnFhir.Common.Services
             _blobContainerClient = _blobServiceClient.GetBlobContainerClient(azureConfiguration.BlobContainerName);
             _authenticationConfiguration = EnsureArg.IsNotNull(authenticationConfiguration, nameof(authenticationConfiguration));
             _jwtSecurityTokenHandlerProvider = EnsureArg.IsNotNull(jwtSecurityTokenHandlerProvider, nameof(jwtSecurityTokenHandlerProvider));
-            _httpClient = EnsureArg.IsNotNull(httpClient, nameof(httpClient));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
         }
 
@@ -143,41 +139,12 @@ namespace Microsoft.Health.FitOnFhir.Common.Services
                 // store state to blob storage
                 await blobClient.UploadAsync(new BinaryData(JsonConvert.SerializeObject(state)), true, cancellationToken);
 
-                // set blob expiry
-                await SetBlobExpiry(blobClient, cancellationToken);
-
                 return nonce;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to store the auth state.");
                 return null;
-            }
-        }
-
-        private async Task SetBlobExpiry(BlobClient blobClient, CancellationToken cancellationToken)
-        {
-
-            var query = new Dictionary<string, string>()
-            {
-                ["comp"] = "expiry",
-            };
-            string url = blobClient.AccountName + '/' + blobClient.BlobContainerName + '/' + blobClient.Name;
-            var uri = QueryHelpers.AddQueryString(url, query);
-            var request = new HttpRequestMessage(HttpMethod.Put, uri)
-            {
-                Headers =
-                {
-                    { "x-ms-expiry-option", "RelativeToNow" },
-                    { "x-ms-expiry-time", "300000" },
-                },
-            };
-
-            var response = await _httpClient.SendAsync(request, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new Exception($"Blob storage expiry not set.  Status:{response.StatusCode} Reason:{response.ReasonPhrase}");
             }
         }
 

--- a/src/Common/FitOnFhir.Common/Services/TokenValidationService.cs
+++ b/src/Common/FitOnFhir.Common/Services/TokenValidationService.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.IdentityModel.Tokens.Jwt;
 using EnsureThat;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
@@ -28,7 +28,10 @@ namespace Microsoft.Health.FitOnFhir.GoogleFit.Tests
         public const string PatientId = "12345678-9101-1121-3141-516171819202";
         public const string ExternalPatientId = "ExternalPatientId";
         public const string ExternalSystem = "ExternalSystem";
-        public const string AuthorizationState = $"{{\"{Constants.ExternalIdQueryParameter}\":\"{ExternalPatientId}\", \"{Constants.ExternalSystemQueryParameter}\":\"{ExternalSystem}\"}}";
+        public const string AuthorizationState = $"{{\"{Constants.ExternalIdQueryParameter}\":\"{ExternalPatientId}\"," +
+                                                 $" \"{Constants.ExternalSystemQueryParameter}\":\"{ExternalSystem}\"," +
+                                                 $" \"ExpirationTimeStamp\":\"1/12/2004 12:01:00 AM -05:00\"}}";
+
         public static readonly AuthState StoredAuthState = JsonConvert.DeserializeObject<AuthState>(AuthorizationState);
 
         public static MedTechDataset GetMedTechDataset(string deviceUid = DeviceUid, string packageName = PackageName, int pointCount = 1)

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/Data.cs
@@ -6,8 +6,10 @@
 using System.IdentityModel.Tokens.Jwt;
 using Google.Apis.Fitness.v1.Data;
 using Microsoft.Health.FitOnFhir.Common;
+using Microsoft.Health.FitOnFhir.Common.Models;
 using Microsoft.Health.FitOnFhir.GoogleFit.Client.Models;
 using Microsoft.Health.FitOnFhir.GoogleFit.Client.Responses;
+using Newtonsoft.Json;
 using Claim = System.Security.Claims.Claim;
 
 namespace Microsoft.Health.FitOnFhir.GoogleFit.Tests
@@ -27,6 +29,7 @@ namespace Microsoft.Health.FitOnFhir.GoogleFit.Tests
         public const string ExternalPatientId = "ExternalPatientId";
         public const string ExternalSystem = "ExternalSystem";
         public const string AuthorizationState = $"{{\"{Constants.ExternalIdQueryParameter}\":\"{ExternalPatientId}\", \"{Constants.ExternalSystemQueryParameter}\":\"{ExternalSystem}\"}}";
+        public static readonly AuthState StoredAuthState = JsonConvert.DeserializeObject<AuthState>(AuthorizationState);
 
         public static MedTechDataset GetMedTechDataset(string deviceUid = DeviceUid, string packageName = PackageName, int pointCount = 1)
         {

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
@@ -34,6 +34,9 @@ namespace Microsoft.Health.FitOnFhir.GoogleFit.Tests
         private readonly DateTimeOffset _now =
             new DateTimeOffset(2004, 1, 12, 0, 0, 0, new TimeSpan(-5, 0, 0));
 
+        private readonly DateTimeOffset _expired =
+            new DateTimeOffset(2004, 1, 12, 0, 2, 0, new TimeSpan(-5, 0, 0));
+
         public UsersServiceTests()
         {
             _googleFitUserRepository = Substitute.For<IGoogleFitUserTableRepository>();
@@ -109,6 +112,13 @@ namespace Microsoft.Health.FitOnFhir.GoogleFit.Tests
         {
             _authService.AuthTokensRequest(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<AuthTokensResponse>(null));
 
+            await Assert.ThrowsAsync<Exception>(async () => await ExecuteAuthorizationCallback());
+        }
+
+        [Fact]
+        public async Task GivenAuthStateExpired_WhenProcessAuthorizationCallbackCalled_ExceptionIsThrown()
+        {
+            _utcNowFunc().Returns(_expired);
             await Assert.ThrowsAsync<Exception>(async () => await ExecuteAuthorizationCallback());
         }
 

--- a/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit.Tests/UsersServiceTests.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.IdentityModel.Tokens.Jwt;
-using Microsoft.Health.FitOnFhir.Common;
 using Microsoft.Health.FitOnFhir.Common.Models;
 using Microsoft.Health.FitOnFhir.Common.Repositories;
 using Microsoft.Health.FitOnFhir.Common.Resolvers;

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Health.FitOnFhir.GoogleFit.Client.Handlers
             catch (Exception ex)
             {
                 _logger.LogError(ex, ex.Message);
-                return new ObjectResult("An unexpected error occurred while attempting to revoke data access.") { StatusCode = StatusCodes.Status500InternalServerError };
+                return new ObjectResult("An unexpected error occurred while attempting to authorize access.") { StatusCode = StatusCodes.Status500InternalServerError };
             }
         }
 

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
@@ -15,7 +15,6 @@ using Microsoft.Health.FitOnFhir.Common.Requests;
 using Microsoft.Health.FitOnFhir.GoogleFit.Client.Responses;
 using Microsoft.Health.FitOnFhir.GoogleFit.Common;
 using Microsoft.Health.FitOnFhir.GoogleFit.Services;
-using Newtonsoft.Json;
 
 namespace Microsoft.Health.FitOnFhir.GoogleFit.Client.Handlers
 {
@@ -117,7 +116,8 @@ namespace Microsoft.Health.FitOnFhir.GoogleFit.Client.Handlers
         {
             try
             {
-                AuthUriResponse response = await _authService.AuthUriRequest(JsonConvert.SerializeObject(state), request.Token);
+                var nonce = await _authStateService.StoreAuthState(state, request.Token);
+                AuthUriResponse response = await _authService.AuthUriRequest(nonce, request.Token);
                 return new RedirectResult(response.Uri);
             }
             catch (Exception ex)

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/IUsersService.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Health.FitOnFhir.GoogleFit.Services
         /// The ID token's subject and issuer are stored as identifiers for a patient in the FHIR server instance.
         /// </summary>
         /// <param name="authCode">The authorization code provided by Google and used to retrieve tokens.</param>
-        /// <param name="state">The <see cref="AuthState"/> which contains the PatientID for the user in the corresponding external medical records system.</param>
+        /// <param name="nonce">The nonce that was used to authorize with the device platform.</param>
         /// <param name="cancellationToken">The token used to cancel the operation.</param>
-        Task ProcessAuthorizationCallback(string authCode, string state, CancellationToken cancellationToken);
+        Task ProcessAuthorizationCallback(string authCode, string nonce, CancellationToken cancellationToken);
 
         /// <summary>
         /// Inserts a <see cref="QueueMessage"/> for the <see cref="User"/> into the Queue identified by the connection string in

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
@@ -76,6 +76,11 @@ namespace Microsoft.Health.FitOnFhir.GoogleFit.Services
                 throw new Exception("An error occurred while validating the Google authorization callback 'state' parameter.");
             }
 
+            if (authState.ExpirationTimeStamp <= _utcNowFunc())
+            {
+                throw new Exception("The authorization attempt failed because it was not completed within the maximum, 5 minute period.");
+            }
+
             // Exchange the code for Auth, Refresh and Id tokens.
             var tokenResponse = await _authService.AuthTokensRequest(authCode, cancellationToken);
 

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Services/UsersService.cs
@@ -66,7 +66,15 @@ namespace Microsoft.Health.FitOnFhir.GoogleFit.Services
             }
 
             var validNonce = EnsureArg.IsNotNullOrWhiteSpace(nonce);
-            AuthState authState = await _authStateService.RetrieveAuthState(validNonce, cancellationToken);
+            AuthState authState;
+            try
+            {
+                authState = await _authStateService.RetrieveAuthState(validNonce, cancellationToken);
+            }
+            catch (Exception)
+            {
+                throw new Exception("An error occurred while validating the Google authorization callback 'state' parameter.");
+            }
 
             // Exchange the code for Auth, Refresh and Id tokens.
             var tokenResponse = await _authService.AuthTokensRequest(authCode, cancellationToken);


### PR DESCRIPTION
Move to new authorization flow, where a nonce is passed to the device platform rather than sensitive data such as an external patient ID or system identifier.  A nonce is generated and used to create a blob store, which is then used to contain the authorization data.  Upon callback from the device platform, the passed back nonce is used to retrieve the authorization data and complete the process.