### PR TITLE
remove duplicate package reference

### DIFF
--- a/src/Common/FitOnFhir.Common.Tests/Microsoft.Health.FitOnFhir.Common.Tests.csproj
+++ b/src/Common/FitOnFhir.Common.Tests/Microsoft.Health.FitOnFhir.Common.Tests.csproj
@@ -22,7 +22,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>	
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
It was discovered that `Microsoft.Health.FitOnFhir.Common.Tests.csproj` contained two package references to `Microsoft.NET.Test.Sdk`.  