### PR TITLE
Authorize function returns JSON object

### DIFF
--- a/src/Common/FitOnFhir.Common.Tests/UsersServiceBaseTests.cs
+++ b/src/Common/FitOnFhir.Common.Tests/UsersServiceBaseTests.cs
@@ -3,12 +3,10 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Net;
 using Microsoft.Health.Extensions.Fhir.Service;
 using Microsoft.Health.FitOnFhir.Common.Interfaces;
 using Microsoft.Health.FitOnFhir.Common.Models;
 using Microsoft.Health.FitOnFhir.Common.Repositories;
-using Microsoft.Health.FitOnFhir.Common.Tests.Mocks;
 using NSubstitute;
 using Xunit;
 using Bundle = Hl7.Fhir.Model.Bundle;

--- a/src/Common/FitOnFhir.Common/Models/AuthorizeResponseData.cs
+++ b/src/Common/FitOnFhir.Common/Models/AuthorizeResponseData.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.FitOnFhir.Common.Serialization;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.FitOnFhir.Common.Models
+{
+    public class AuthorizeResponseData
+    {
+        [JsonConstructor]
+        public AuthorizeResponseData()
+        {
+        }
+
+        public AuthorizeResponseData(string authUrl, DateTimeOffset expiresAt)
+        {
+            AuthUrl = authUrl;
+            ExpiresAt = expiresAt;
+        }
+
+        [JsonProperty(nameof(AuthUrl))]
+        [JsonConverter(typeof(UrlSafeJsonConverter))]
+        [JsonRequired]
+        public string AuthUrl { get; set; }
+
+        [JsonProperty(nameof(ExpiresAt))]
+        [JsonRequired]
+        public DateTimeOffset ExpiresAt { get; set; }
+    }
+}

--- a/src/Common/FitOnFhir.Common/Models/AuthorizeResponseData.cs
+++ b/src/Common/FitOnFhir.Common/Models/AuthorizeResponseData.cs
@@ -21,12 +21,9 @@ namespace Microsoft.Health.FitOnFhir.Common.Models
             ExpiresAt = expiresAt;
         }
 
-        [JsonProperty(nameof(AuthUrl))]
-        [JsonConverter(typeof(UrlSafeJsonConverter))]
         [JsonRequired]
         public string AuthUrl { get; set; }
 
-        [JsonProperty(nameof(ExpiresAt))]
         [JsonRequired]
         public DateTimeOffset ExpiresAt { get; set; }
     }

--- a/src/Common/FitOnFhir.Common/Models/AuthorizeResponseData.cs
+++ b/src/Common/FitOnFhir.Common/Models/AuthorizeResponseData.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.FitOnFhir.Common.Serialization;
 using Newtonsoft.Json;
 
 namespace Microsoft.Health.FitOnFhir.Common.Models
@@ -21,9 +20,11 @@ namespace Microsoft.Health.FitOnFhir.Common.Models
             ExpiresAt = expiresAt;
         }
 
+        [JsonProperty("authUrl")]
         [JsonRequired]
         public string AuthUrl { get; set; }
 
+        [JsonProperty("expiresAt")]
         [JsonRequired]
         public DateTimeOffset ExpiresAt { get; set; }
     }

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Client/Handlers/GoogleFitAuthorizationHandler.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Net;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -16,6 +17,7 @@ using Microsoft.Health.FitOnFhir.Common.Requests;
 using Microsoft.Health.FitOnFhir.GoogleFit.Client.Responses;
 using Microsoft.Health.FitOnFhir.GoogleFit.Common;
 using Microsoft.Health.FitOnFhir.GoogleFit.Services;
+using Newtonsoft.Json;
 
 namespace Microsoft.Health.FitOnFhir.GoogleFit.Client.Handlers
 {
@@ -123,7 +125,8 @@ namespace Microsoft.Health.FitOnFhir.GoogleFit.Client.Handlers
             {
                 var nonce = await _authStateService.StoreAuthState(state, request.Token);
                 AuthUriResponse response = await _authService.AuthUriRequest(nonce, request.Token);
-                return new RedirectResult(response.Uri);
+                return new JsonResult(JsonConvert.SerializeObject(new AuthorizeResponseData(response.Uri, state.ExpirationTimeStamp)))
+                    { StatusCode = (int?)HttpStatusCode.OK };
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Currently the Authorize function returns a redirect result with the URL to grant permission for accessing Google Fit data.  Through testing it was determined that built-in security checks (related to CORS) for modern browsers, do not allow for cross origin redirects.  To prevent this from being a problem, a new `AuthorizeResponseData` type is returned as JSON to the requester.  Contained within `AuthorizeResponseData` are two properties.  `AuthUrl` contains the URL that the user needs to navigate to, in order to complete the authorization flow with Google Fit.  `ExpiresAt` contains the `DateTimeOffset` value for when granted access to the `AuthURL` will expire.