### PR TITLE
Updated Azure.Identity package version

### DIFF
--- a/src/Common/FitOnFhir.Common/Microsoft.Health.FitOnFhir.Common.csproj
+++ b/src/Common/FitOnFhir.Common/Microsoft.Health.FitOnFhir.Common.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.1" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.9.2" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.17.0" />

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Microsoft.Health.FitOnFhir.GoogleFit.csproj
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Microsoft.Health.FitOnFhir.GoogleFit.csproj
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.1" />
-    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.9.2" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />

--- a/src/GoogleFit/FitOnFhir.GoogleFit/Microsoft.Health.FitOnFhir.GoogleFit.csproj
+++ b/src/GoogleFit/FitOnFhir.GoogleFit/Microsoft.Health.FitOnFhir.GoogleFit.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.1" />
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.9.2" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />


### PR DESCRIPTION
Fixing Azure.Identity Component Governance alert.
- Added Azure.Identity 1.10.3 to `Microsoft.Health.FitOnFhir.Common` because `TokenCredentialProvider` in it is [using Azure.Identity](https://github.com/microsoft/fit-on-fhir/blob/main/src/Common/FitOnFhir.Common/Providers/TokenCredentialProvider.cs#L7).
- Removed Azure.Identity from `Microsoft.Health.FitOnFhir.GoogleFit` because nothing in it seems to be using Azure.Identity. The solution still builds fine.